### PR TITLE
Add configurable CORS origins and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Create `backend/.topsecret` (env file) with at least:
 ```
 DATABASE_URL=postgresql://user:pass@host:5432/db
 SECRET_KEY=change-me
-ALLOWED_ORIGINS=["http://localhost:4200"]
+# Comma-separated or JSON list; defaults cover localhost/127.0.0.1 for ports 3000 and 4200
+ALLOWED_ORIGINS=http://localhost:4200,http://localhost:3000
 AUTO_CREATE_TABLES=true
 # Email (optional)
 SMTP_HOST=smtp.mailhost.com
@@ -36,7 +37,7 @@ SMTP_USE_TLS=true
 ```
 
 Key settings:
-- `ALLOWED_ORIGINS`: CORS origins list (comma/JSON list).
+- `ALLOWED_ORIGINS`: CORS origins list (comma/JSON list). Defaults suit local dev; set staging/prod origins as needed.
 - `AUTO_CREATE_TABLES`: Set `true` for local/dev convenience; use migrations in prod.
 - `SECRET_KEY`: JWT signing secret.
 - `DATABASE_URL`: Point to Postgres/SQLite/etc.

--- a/backend/README.md
+++ b/backend/README.md
@@ -6,7 +6,7 @@ Environment variables (or `.topsecret` file) are loaded via `pydantic-settings`:
 
 - `DATABASE_URL` (required)
 - `SECRET_KEY` (required)
-- `ALLOWED_ORIGINS` (list, e.g. `["http://localhost:4200"]`)
+- `ALLOWED_ORIGINS` (comma-separated or JSON list; defaults to localhost/127.0.0.1 on ports 3000 and 4200)
 - `AUTO_CREATE_TABLES` (bool; enable for local dev only)
 - `ACCESS_TOKEN_EXPIRE_MINUTES` (default 30)
 - SMTP: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_SENDER`, `SMTP_USE_TLS`
@@ -32,6 +32,6 @@ python -m unittest tests.test_api
 
 ## Notes
 
-- CORS origins are configurable; avoid `*` when using credentials.
+- CORS origins are configurable via `ALLOWED_ORIGINS`; defaults target localhost/127.0.0.1 for dev—set staging/prod hosts explicitly (avoid `*` when using credentials).
 - Email sending is optional and failures are logged without breaking the request.
 - In production, manage schema with migrations instead of `AUTO_CREATE_TABLES`.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,15 @@
+import json
+
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+DEFAULT_ALLOWED_ORIGINS = [
+    "http://localhost:4200",
+    "http://127.0.0.1:4200",
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+]
 
 
 class Settings(BaseSettings):
@@ -6,7 +17,7 @@ class Settings(BaseSettings):
     secret_key: str
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 30
-    allowed_origins: list[str] = ["http://localhost:4200"]
+    allowed_origins: list[str] = DEFAULT_ALLOWED_ORIGINS
     auto_create_tables: bool = False
     organizer_invite_code: str | None = None
     smtp_host: str | None = None
@@ -17,6 +28,28 @@ class Settings(BaseSettings):
     smtp_use_tls: bool = True
     
     model_config = SettingsConfigDict(env_file=".topsecret", extra="ignore")
+
+    @field_validator("allowed_origins", mode="before")
+    @classmethod
+    def parse_allowed_origins(cls, value):
+        if value is None or value == "":
+            return list(DEFAULT_ALLOWED_ORIGINS)
+
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+                if isinstance(parsed, list):
+                    return [origin for origin in parsed if origin]
+            except json.JSONDecodeError:
+                pass
+
+            parsed = [origin.strip() for origin in value.split(",")]
+            return [origin for origin in parsed if origin]
+
+        if isinstance(value, (list, tuple)):
+            return [origin for origin in value if origin]
+
+        raise ValueError("allowed_origins must be a list or comma-separated string")
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- add flexible parsing for ALLOWED_ORIGINS with sensible localhost defaults and support for comma-separated or JSON env values
- document the updated CORS configuration in backend and root README files

## Testing
- python -m unittest tests.test_api *(fails: missing `httpx` dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924b496da588332a289528718b30759)