### PR TITLE
test: add guard coverage for auth and organizer routes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@
 - [x] Event validation: max length constraints, cover_url validation, password complexity; return structured errors.
 - [x] Recommendations: exclude past events and respect capacity/full state.
 - [x] Event pagination: add controls for page size selection and display total pages; update backend tests for page_size.
-- [ ] Add 403/404 routing guards coverage in Angular tests.
+- [x] Add 403/404 routing guards coverage in Angular tests.
 - [ ] CI pipeline (GitHub Actions): install deps, run backend tests, run Angular tests.
 
 ## Medium

--- a/ui/src/app/guards/auth.guard.spec.ts
+++ b/ui/src/app/guards/auth.guard.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, UrlTree } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { authGuard } from './auth.guard';
+import { AuthService } from '../services/auth.service';
+
+class AuthStub {
+  loggedIn = false;
+  role: string | null = null;
+  isLoggedIn() {
+    return this.loggedIn;
+  }
+  isOrganizer() {
+    return this.role === 'organizator';
+  }
+}
+
+describe('authGuard', () => {
+  let router: Router;
+  let auth: AuthStub;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule.withRoutes([])],
+      providers: [{ provide: AuthService, useClass: AuthStub }],
+    });
+    router = TestBed.inject(Router);
+    auth = TestBed.inject(AuthService) as unknown as AuthStub;
+  });
+
+  it('redirects unauthenticated users to login with redirect param', () => {
+    const tree = TestBed.runInInjectionContext(() => authGuard({ data: {} } as any, { url: '/protected' } as any));
+    expect(tree instanceof UrlTree).toBeTrue();
+    expect((tree as UrlTree).toString()).toContain('/login');
+    expect((tree as UrlTree).queryParams['redirect']).toBe('/protected');
+  });
+
+  it('redirects wrong role users to home', () => {
+    auth.loggedIn = true;
+    auth.role = 'student';
+    const tree = TestBed.runInInjectionContext(() => authGuard({ data: { role: 'organizator' } } as any, { url: '/org' } as any));
+    expect(tree instanceof UrlTree).toBeTrue();
+    expect((tree as UrlTree).toString()).toBe('/');
+  });
+
+  it('allows access when role matches', () => {
+    auth.loggedIn = true;
+    auth.role = 'student';
+    const result = TestBed.runInInjectionContext(() => authGuard({ data: { role: 'student' } } as any, { url: '/s' } as any));
+    expect(result).toBeTrue();
+  });
+});

--- a/ui/src/app/guards/organizer.guard.spec.ts
+++ b/ui/src/app/guards/organizer.guard.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, UrlTree } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { organizerGuard } from './organizer.guard';
+import { AuthService } from '../services/auth.service';
+
+class AuthStub {
+  loggedIn = false;
+  role: string | null = null;
+  isLoggedIn() {
+    return this.loggedIn;
+  }
+  isOrganizer() {
+    return this.role === 'organizator';
+  }
+}
+
+describe('organizerGuard', () => {
+  let router: Router;
+  let auth: AuthStub;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule.withRoutes([])],
+      providers: [{ provide: AuthService, useClass: AuthStub }],
+    });
+    router = TestBed.inject(Router);
+    auth = TestBed.inject(AuthService) as unknown as AuthStub;
+  });
+
+  it('redirects unauthenticated to login', () => {
+    const tree = TestBed.runInInjectionContext(() => organizerGuard({} as any, {} as any));
+    expect(tree instanceof UrlTree).toBeTrue();
+    expect((tree as UrlTree).toString()).toContain('/login');
+  });
+
+  it('redirects non-organizer to forbidden', () => {
+    auth.loggedIn = true;
+    auth.role = 'student';
+    const tree = TestBed.runInInjectionContext(() => organizerGuard({} as any, {} as any));
+    expect(tree instanceof UrlTree).toBeTrue();
+    expect((tree as UrlTree).toString()).toBe('/forbidden');
+  });
+
+  it('allows organizers', () => {
+    auth.loggedIn = true;
+    auth.role = 'organizator';
+    const result = TestBed.runInInjectionContext(() => organizerGuard({} as any, {} as any));
+    expect(result).toBeTrue();
+  });
+});


### PR DESCRIPTION
**Summary**
- Add unit tests covering auth and organizer guards for login/role redirects.

**Changes**
- Added specs for `authGuard` and `organizerGuard` verifying redirects for unauthenticated/incorrect roles and allow access when permitted.
- Updated TODO to mark guard coverage done.

**Testing**
- cd ui && npm test -- --watch=false

**Risk & Impact**
- Tests only; no runtime changes.

**Related TODO items**
- [x] Add 403/404 routing guards coverage in Angular tests.
