### PR TITLE
chore: add ci pipeline for backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install backend deps
+        run: |
+          cd backend
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run backend tests
+        run: |
+          cd backend
+          python -m unittest tests.test_api
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install frontend deps
+        run: |
+          cd ui
+          npm ci
+      - name: Run frontend tests
+        run: |
+          cd ui
+          npm test -- --watch=false

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@
 - [x] Recommendations: exclude past events and respect capacity/full state.
 - [x] Event pagination: add controls for page size selection and display total pages; update backend tests for page_size.
 - [x] Add 403/404 routing guards coverage in Angular tests.
-- [ ] CI pipeline (GitHub Actions): install deps, run backend tests, run Angular tests.
+- [x] CI pipeline (GitHub Actions): install deps, run backend tests, run Angular tests.
 - [ ] Make sure emailing actually works, and configure it otherwise so that mails are being sent.
 
 ## Medium


### PR DESCRIPTION
**Summary**
- Add GitHub Actions CI to run backend and frontend tests on pushes/PRs.

**Changes**
- Added `.github/workflows/ci.yml` to install deps and run backend unittest suite plus Angular karma tests.
- Updated TODO to mark CI pipeline task as complete.

**Testing**
- Not run locally (workflow definition only). Backend tests previously pass via `python3 -m unittest tests.test_api`; frontend via `npm test -- --watch=false`.

**Risk & Impact**
- CI may initially fail if dependencies or Node version need tweaks; adjust workflow as needed.

**Related TODO items**
- [x] CI pipeline (GitHub Actions): install deps, run backend tests, run Angular tests.
