### PR TITLE
chore: add httpx dependency for tests

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,4 +16,5 @@ dependencies = [
     "python-multipart",
     "pydantic[email]>=2.12.3",
     "alembic>=1.14.0",
+    "httpx>=0.28.1",
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,8 @@ bcrypt==4.0.1
     # via
     #   event-link-backend (pyproject.toml)
     #   passlib
+certifi==2024.8.30
+    # via httpx
 alembic==1.14.0
     # via event-link-backend (pyproject.toml)
 cffi==2.0.0
@@ -30,11 +32,18 @@ fastapi==0.121.2
     # via event-link-backend (pyproject.toml)
 greenlet==3.2.4
     # via sqlalchemy
+h11==0.14.0
+    # via httpx
 h11==0.16.0
     # via uvicorn
+httpcore==1.0.5
+    # via httpx
+httpx==0.28.1
+    # via event-link-backend (pyproject.toml)
 idna==3.11
     # via
     #   anyio
+    #   httpx
     #   email-validator
 mako==1.3.5
     # via alembic


### PR DESCRIPTION
**Summary**
- Add httpx as a dependency to support FastAPI TestClient and related tooling.

**Changes**
- Added httpx to backend pyproject dependencies and locked requirements.

**Testing**
- python3 -m unittest tests.test_api

**Risk & Impact**
- Low; dependency addition only.

**Related TODO items**
- (dependency fix to keep backend tests passing)
