### PR TITLE
chore: mark completed EL user stories in backlog

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,15 +1,15 @@
 # TODO (Event Link)
 
 ## High
-- [ ] [EL-3] Student signup: allow students to create an account with email + password so they can register for events.
-- [ ] [EL-4] User login: allow both students and organizers to log into their account securely to use the platform.
-- [ ] [EL-6] Organizer create event form: provide a form for organizers to create and publish new events.
-- [ ] [EL-12] Enforce capacity limits: automatically stop new registrations when an event reaches its maximum number of seats.
-- [ ] [EL-13] Student event list: show a list of all upcoming events on the main page so students stay informed about what’s happening.
-- [ ] [EL-14] Event details page: when a student clicks an event in the list, show a full details page (description, time, organizer, location, etc.).
-- [ ] [EL-15] Event registration button: on the event details page, show an “Enroll / Register” button for logged‑in students to reserve a spot.
-- [ ] [EL-21] Event tags for recommendations: allow organizers to add relevant tags to events so the recommendation engine can match events to interested students.
-- [ ] [EL-22] “Recommended for you” section: show students a personalized list of recommended events based on their registration history.
+- [x] [EL-3] Student signup: allow students to create an account with email + password so they can register for events.
+- [x] [EL-4] User login: allow both students and organizers to log into their account securely to use the platform.
+- [x] [EL-6] Organizer create event form: provide a form for organizers to create and publish new events.
+- [x] [EL-12] Enforce capacity limits: automatically stop new registrations when an event reaches its maximum number of seats.
+- [x] [EL-13] Student event list: show a list of all upcoming events on the main page so students stay informed about what’s happening.
+- [x] [EL-14] Event details page: when a student clicks an event in the list, show a full details page (description, time, organizer, location, etc.).
+- [x] [EL-15] Event registration button: on the event details page, show an “Enroll / Register” button for logged‑in students to reserve a spot.
+- [x] [EL-21] Event tags for recommendations: allow organizers to add relevant tags to events so the recommendation engine can match events to interested students.
+- [x] [EL-22] “Recommended for you” section: show students a personalized list of recommended events based on their registration history.
 - [x] Add Alembic migrations and replace `AUTO_CREATE_TABLES` in production; generate migration for cover_url/attended columns.
 - [x] Harden auth: central organizer/student dependency helpers, consistent JWT expiry validation, and rate limit login/register.
 - [x] Implement global exception/response wrapper for consistent error payloads (code/message) across APIs.
@@ -26,11 +26,11 @@
 - [x] Make sure emailing actually works, and configure it otherwise so that mails are being sent.
 
 ## Medium
-- [ ] [EL-7] Organizer edit event: allow organizers to edit details of events they created (title, description, time, capacity, etc.).
-- [ ] [EL-8] Organizer delete event: allow organizers to delete/cancel an event they created when it will no longer take place.
-- [ ] [EL-9] Organizer event dashboard: provide a page where organizers can see a list of all events they have created for centralized management.
-- [ ] [EL-10] Participant list for organizers: show organizers the list of students registered for one of their events so they can manage attendance.
-- [ ] [EL-16] “My Events” page for students: provide a page where a logged‑in student can see the list of events they are registered for.
+- [x] [EL-7] Organizer edit event: allow organizers to edit details of events they created (title, description, time, capacity, etc.).
+- [x] [EL-8] Organizer delete event: allow organizers to delete/cancel an event they created when it will no longer take place.
+- [x] [EL-9] Organizer event dashboard: provide a page where organizers can see a list of all events they have created for centralized management.
+- [x] [EL-10] Participant list for organizers: show organizers the list of students registered for one of their events so they can manage attendance.
+- [x] [EL-16] “My Events” page for students: provide a page where a logged‑in student can see the list of events they are registered for.
 - [x] Docker + docker-compose for backend/frontend/Postgres with env wiring and docs.
 - [x] Security headers middleware (HSTS, X-Content-Type-Options, X-Frame-Options) and CORS audit.
 - [x] Health/readiness endpoint to check DB connectivity for probes.
@@ -60,10 +60,10 @@
 - [ ] CI caching for npm/pip to speed up pipelines and document cache keys.
 
 ## Low
-- [ ] [EL-17] Search events by name: let students search events by title to quickly find something specific.
-- [ ] [EL-18] Filter events by category: allow students to filter events by category (e.g., technical, cultural, sports) to see only relevant events.
-- [ ] [EL-19] Registration confirmation email: send an email notification to students when they successfully register for an event.
-- [ ] [EL-20] Filter events by date/interval: allow students to filter events by a date range to find events that fit their schedule.
+- [x] [EL-17] Search events by name: let students search events by title to quickly find something specific.
+- [x] [EL-18] Filter events by category: allow students to filter events by category (e.g., technical, cultural, sports) to see only relevant events.
+- [x] [EL-19] Registration confirmation email: send an email notification to students when they successfully register for an event.
+- [x] [EL-20] Filter events by date/interval: allow students to filter events by a date range to find events that fit their schedule.
 - [ ] Add Prettier/ESLint config and `npm run lint` hook; backend ruff/black + make lint.
 - [ ] Seed data/scripts for local dev (sample users/events with tags/covers).
 - [ ] Add API docs updates for new endpoints (unregister, attendance toggle, organizer upgrade).


### PR DESCRIPTION
**Summary**
- Update TODO backlog to mark EL-3/4/6/12/13/14/15/21/22 and EL-7/8/9/10/16 plus EL-17/18/19/20 as completed, reflecting current implementation status.

**Changes**
- Checked off high/medium/low EL user stories already implemented across backend/frontend.

**Testing**
- Not run (documentation-only change).

**Risk & Impact**
- None; backlog update only.

**Related TODO items**
- [x] [EL-3] Student signup
- [x] [EL-4] User login
- [x] [EL-6] Organizer create event form
- [x] [EL-12] Enforce capacity limits
- [x] [EL-13] Student event list
- [x] [EL-14] Event details page
- [x] [EL-15] Event registration button
- [x] [EL-21] Event tags for recommendations
- [x] [EL-22] “Recommended for you” section
- [x] [EL-7] Organizer edit event
- [x] [EL-8] Organizer delete event
- [x] [EL-9] Organizer event dashboard
- [x] [EL-10] Participant list for organizers
- [x] [EL-16] “My Events” page for students
- [x] [EL-17] Search events by name
- [x] [EL-18] Filter events by category
- [x] [EL-19] Registration confirmation email
- [x] [EL-20] Filter events by date/interval