### PR TITLE
chore: add test hardening tasks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,6 +53,8 @@
 - [x] ICS calendar export for events and calendar subscription per user.
 - [x] Configuration sanity checks at startup (fail fast if essential env vars are missing).
 - [x] Full mobile/phone compatibility across core pages (nav, event lists/details/forms).
+- [ ] Backend pytest migration + coverage thresholds for core flows (auth, events, register, recommendations, reset).
+- [ ] Frontend Angular unit test fixes (ActivatedRoute providers) + coverage thresholds; stabilize CI headless runs.
 - [ ] End-to-end tests (Playwright) for auth, event browse, register/unregister, and organizer edit flows.
 - [ ] Stress/load tests for critical endpoints (event list, registration, recommendations).
 - [ ] Pagination and sorting for all list endpoints (registrations, users).


### PR DESCRIPTION
**Summary**
Add backlog items to harden testing: backend pytest migration/coverage and frontend Angular unit test fixes/coverage.

**Changes**
- Update TODO.md with test hardening tasks for backend pytest/coverage and frontend Angular unit test fixes/coverage.

**Testing**
- Not required (docs only).

**Risk & Impact**
- None.

**Related TODO items**
- [ ] Backend pytest migration + coverage thresholds for core flows (auth, events, register, recommendations, reset).
- [ ] Frontend Angular unit test fixes (ActivatedRoute providers) + coverage thresholds; stabilize CI headless runs.
