### PR TITLE
fix: cleanup register endpoint signature

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -637,7 +637,6 @@ def update_participant_attendance(
 def register_for_event(
     event_id: int,
     background_tasks: BackgroundTasks,
-    request: Request | None = None,
     db: Session = Depends(get_db),
     current_user: models.User = Depends(auth.require_student),
     request: Request | None = None,


### PR DESCRIPTION
**Summary**
- Fix duplicate `request` argument in `register_for_event`, which caused pytest collection to fail.

**Changes**
- Removed the extra `request` parameter so the endpoint signature is valid and keeps `request` optional at the end.

**Testing**
- Please re-run backend tests: `cd backend && pytest` (should now parse api.py).

**Risk & Impact**
- No behavioral changes beyond fixing the syntax error.

**Related TODO items**
- n/a (CI unblock).