### PR TITLE
fix: align frontend CI with Vite checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           cd ui
           npm ci
-      - name: Run frontend tests
+      - name: Run frontend checks
         run: |
           cd ui
-          npm test -- --watch=false --browsers=ChromeHeadless --code-coverage
+          npm test

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ coverage.xml
 .Trashes
 ehthumbs.db
 Thumbs.db
+*:Zone.Identifier
 
 # Logs
 logs/
@@ -156,7 +157,7 @@ celerybeat-schedule
 
 # Spyder project settings
 .spyderproject
-.spyproject
+spyproject
 
 # Rope project settings
 .ropeproject

--- a/TODO.md
+++ b/TODO.md
@@ -25,6 +25,7 @@
 - [x] CI pipeline (GitHub Actions): install deps, run backend tests, run Angular tests.
 - [x] CI: run Angular tests headless (ChromeHeadless) to avoid display errors in Actions.
 - [x] Make sure emailing actually works, and configure it otherwise so that mails are being sent.
+- [x] Fix frontend CI for the Vite/React UI (`npm test` script + Actions workflow step).
 
 ## Medium
 - [x] [EL-7] Organizer edit event: allow organizers to edit details of events they created (title, description, time, capacity, etc.).
@@ -69,6 +70,7 @@
 - [x] [EL-19] Registration confirmation email: send an email notification to students when they successfully register for an event.
 - [x] [EL-20] Filter events by date/interval: allow students to filter events by a date range to find events that fit their schedule.
 - [ ] Add Prettier/ESLint config and `npm run lint` hook; backend ruff/black + make lint.
+- [x] Ignore Windows `:Zone.Identifier` artifacts in git (prevent dirty working tree on Linux/macOS).
 - [ ] Seed data/scripts for local dev (sample users/events with tags/covers).
 - [ ] Add API docs updates for new endpoints (unregister, attendance toggle, organizer upgrade).
 - [ ] Convert backend tests to pytest and expand fixtures for speed.

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -15,9 +15,21 @@ export default defineConfig([
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
     ],
+    rules: {
+      'react-refresh/only-export-components': [
+        'error',
+        { allowConstantExport: true, allowExportNames: ['useAuth'] },
+      ],
+    },
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+  },
+  {
+    files: ['src/components/ui/**/*.{ts,tsx}'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
     },
   },
 ])

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "npm run lint && npm run build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/ui/src/hooks/use-toast.ts
+++ b/ui/src/hooks/use-toast.ts
@@ -63,7 +63,7 @@ const addToRemoveQueue = (toastId: string) => {
   const timeout = setTimeout(() => {
     toastTimeouts.delete(toastId)
     dispatch({
-      type: "REMOVE_TOAST",
+      type: actionTypes.REMOVE_TOAST,
       toastId: toastId,
     })
   }, TOAST_REMOVE_DELAY)
@@ -73,13 +73,13 @@ const addToRemoveQueue = (toastId: string) => {
 
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
-    case "ADD_TOAST":
+    case actionTypes.ADD_TOAST:
       return {
         ...state,
         toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
       }
 
-    case "UPDATE_TOAST":
+    case actionTypes.UPDATE_TOAST:
       return {
         ...state,
         toasts: state.toasts.map((t) =>
@@ -87,7 +87,7 @@ export const reducer = (state: State, action: Action): State => {
         ),
       }
 
-    case "DISMISS_TOAST": {
+    case actionTypes.DISMISS_TOAST: {
       const { toastId } = action
 
       if (toastId) {
@@ -110,7 +110,7 @@ export const reducer = (state: State, action: Action): State => {
         ),
       }
     }
-    case "REMOVE_TOAST":
+    case actionTypes.REMOVE_TOAST:
       if (action.toastId === undefined) {
         return {
           ...state,
@@ -142,13 +142,13 @@ function toast({ ...props }: Toast) {
 
   const update = (props: ToasterToast) =>
     dispatch({
-      type: "UPDATE_TOAST",
+      type: actionTypes.UPDATE_TOAST,
       toast: { ...props, id },
     })
-  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+  const dismiss = () => dispatch({ type: actionTypes.DISMISS_TOAST, toastId: id })
 
   dispatch({
-    type: "ADD_TOAST",
+    type: actionTypes.ADD_TOAST,
     toast: {
       ...props,
       id,
@@ -182,7 +182,7 @@ function useToast() {
   return {
     ...state,
     toast,
-    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+    dismiss: (toastId?: string) => dispatch({ type: actionTypes.DISMISS_TOAST, toastId }),
   }
 }
 


### PR DESCRIPTION
- **Summary**
  - Fixes failing frontend CI by aligning the workflow with the Vite/React UI (adds a proper `npm test` script and runs it in GitHub Actions).

- **Changes**
  - Update `.github/workflows/ci.yml` to run `npm test` in `ui/` (instead of Angular CLI args).
  - Add `ui` `test` script that runs `lint` + `build` for CI smoke checks.
  - Tweak `ui/eslint.config.js` to avoid `react-refresh/only-export-components` false positives in `ui/src/components/ui/*`.
  - Fix `ui/src/hooks/use-toast.ts` to use typed `actionTypes` constants (removes unused-var lint error).
  - Ignore Windows `*:Zone.Identifier` artifacts in `.gitignore`.

- **Testing**
  - `backend/.venv/bin/pytest` (23 passed)
  - `cd ui && npm ci && npm test` (passes; eslint shows 2 warnings from `react-hooks/exhaustive-deps`, no errors)

- **Risk & Impact**
  - Low. CI now reflects the current UI stack.
  - Note: `npm test` is currently a lint+build smoke check (no unit test runner yet).

- **Related TODO items**
  - [x] Fix frontend CI for the Vite/React UI (`npm test` script + Actions workflow step).
  - [x] Ignore Windows `:Zone.Identifier` artifacts in git (prevent dirty working tree on Linux/macOS).
