### PR TITLE
chore: document GitHub auth and cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ event-link/
 - **Python**: 3.11+
 - **Docker**: optional, for containerized runs
 
+## GitHub credentials (Codex/MCP + git)
+
+If you use Codex GitHub MCP tooling or want `git push` to work without interactive prompts, see
+`docs/github-auth.md`.
+
 ## Backend configuration
 
 Environment is read from `.topsecret` in `backend/` (or standard env vars). Minimum settings:

--- a/TODO.md
+++ b/TODO.md
@@ -71,6 +71,8 @@
 - [x] [EL-20] Filter events by date/interval: allow students to filter events by a date range to find events that fit their schedule.
 - [ ] Add Prettier/ESLint config and `npm run lint` hook; backend ruff/black + make lint.
 - [x] Ignore Windows `:Zone.Identifier` artifacts in git (prevent dirty working tree on Linux/macOS).
+- [x] Document GitHub auth for Codex/MCP + git (`GITHUB_MCP_PAT` / `GH_TOKEN`) and add a local env template.
+- [x] Add a repo script to delete `*:Zone.Identifier` artifacts from a checkout.
 - [ ] Seed data/scripts for local dev (sample users/events with tags/covers).
 - [ ] Add API docs updates for new endpoints (unregister, attendance toggle, organizer upgrade).
 - [ ] Convert backend tests to pytest and expand fixtures for speed.

--- a/docs/github-auth.md
+++ b/docs/github-auth.md
@@ -1,0 +1,50 @@
+# GitHub credentials (Codex/MCP + git)
+
+This repo is commonly used with Codex + GitHub MCP, plus standard `git`/`gh` workflows.
+To avoid interactive prompts (and to keep secrets out of the repo), use environment variables.
+
+## Environment variables
+
+- `GITHUB_MCP_PAT`: Personal Access Token used by the official GitHub MCP server (see `~/.codex/config.toml`).
+- `GH_TOKEN`: Token used by GitHub CLI (`gh`) and tools built on top of it (including `gh-cli-mcp`).
+
+Never commit tokens. Prefer storing them in your shell environment, a password manager/OS keychain,
+or a local-only env file.
+
+## Option A (recommended): `gh` CLI login + setup
+
+This avoids putting a token in your git remote URL.
+
+```bash
+gh auth login
+gh auth setup-git
+```
+
+## Option B: PAT via git credential helper (HTTPS)
+
+If you already have a token, store it in the git credential helper so `git push` won’t block
+waiting for a prompt.
+
+```bash
+git config --global credential.helper store
+printf "protocol=https\nhost=github.com\nusername=x-access-token\npassword=$GH_TOKEN\n\n" | git credential approve
+```
+
+If you use `GITHUB_MCP_PAT` instead of `GH_TOKEN`, set `GH_TOKEN` to the same value in your shell:
+
+```bash
+export GH_TOKEN="$GITHUB_MCP_PAT"
+```
+
+## Making tokens available to Codex/MCP
+
+The Codex GitHub MCP server configuration typically references the env var name:
+
+```toml
+[mcp_servers.github]
+bearer_token_env_var = "GITHUB_MCP_PAT"
+```
+
+If Codex is not inheriting your shell environment, set `shell_environment_policy.inherit = "all"`
+in `~/.codex/config.toml`.
+

--- a/env.tools.example
+++ b/env.tools.example
@@ -1,0 +1,11 @@
+# Developer tooling env (DO NOT COMMIT real tokens)
+#
+# Copy to `.env.tools` (ignored by git) and load it in your shell:
+#   set -a && source .env.tools && set +a
+#
+# Used by Codex GitHub MCP server (see ~/.codex/config.toml):
+GITHUB_MCP_PAT=
+#
+# Used by GitHub CLI (`gh`) and can be used for git HTTPS auth:
+GH_TOKEN=
+

--- a/scripts/cleanup-zone-identifier.sh
+++ b/scripts/cleanup-zone-identifier.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+find "$repo_root" -name '*:Zone.Identifier' -type f -delete
+
+echo "Removed Zone.Identifier artifacts under: $repo_root"
+


### PR DESCRIPTION
- **Summary**
  - Adds lightweight documentation/templates for GitHub credentials used by Codex/MCP and standard `git`/`gh` workflows.

- **Changes**
  - Add `docs/github-auth.md` describing `GITHUB_MCP_PAT` / `GH_TOKEN` and non-interactive git auth options.
  - Add `env.tools.example` template for local-only tooling env vars.
  - Add `scripts/cleanup-zone-identifier.sh` to remove `*:Zone.Identifier` artifacts from a checkout.
  - Link the new docs from `README.md`.
  - Update `TODO.md` with the completed maintenance items.

- **Testing**
  - Not applicable (docs/scripts only).

- **Risk & Impact**
  - Low. No runtime code changes.

- **Related TODO items**
  - [x] Document GitHub auth for Codex/MCP + git (`GITHUB_MCP_PAT` / `GH_TOKEN`) and add a local env template.
  - [x] Add a repo script to delete `*:Zone.Identifier` artifacts from a checkout.
