### PR TITLE
feat: wire organizer upgrade and calendar/email actions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,10 @@
 # TODO (Event Link)
 
 ## High
+- [x] React UI: add organizer upgrade flow (invite code) wired to `POST /organizer/upgrade`.
+- [x] React UI: add “Resend registration email” action wired to `POST /api/events/{id}/register/resend`.
+- [x] React UI: add “My calendar (.ics)” download wired to `GET /api/me/calendar` (auth required).
+- [x] Fix Student Profile interest tag toggling (avoid double-toggle when clicking the checkbox).
 - [x] Localization (RO/EN) for UI labels and outbound emails with Accept-Language support.
 - [x] [EL-3] Student signup: allow students to create an account with email + password so they can register for events.
 - [x] [EL-4] User login: allow both students and organizers to log into their account securely to use the platform.

--- a/ui/src/pages/events/EventDetailPage.tsx
+++ b/ui/src/pages/events/EventDetailPage.tsx
@@ -29,6 +29,7 @@ export function EventDetailPage() {
   const [event, setEvent] = useState<EventDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isRegistering, setIsRegistering] = useState(false);
+  const [isResendingEmail, setIsResendingEmail] = useState(false);
   const [isFavoriting, setIsFavoriting] = useState(false);
   const [isCloning, setIsCloning] = useState(false);
   const { toast } = useToast();
@@ -121,6 +122,29 @@ export function EventDetailPage() {
       });
     } finally {
       setIsRegistering(false);
+    }
+  };
+
+  const handleResendRegistrationEmail = async () => {
+    if (!event) return;
+
+    setIsResendingEmail(true);
+    try {
+      await eventService.resendRegistrationEmail(event.id);
+      toast({
+        title: 'Email trimis',
+        description: 'Am retrimis emailul de confirmare pentru acest eveniment.',
+        variant: 'success' as const,
+      });
+    } catch (error: unknown) {
+      const axiosError = error as { response?: { data?: { detail?: string } } };
+      toast({
+        title: 'Eroare',
+        description: axiosError.response?.data?.detail || 'Nu am putut retrimite emailul',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsResendingEmail(false);
     }
   };
 
@@ -378,6 +402,14 @@ export function EventDetailPage() {
                           ✓ Ești înscris la acest eveniment
                         </p>
                       </div>
+                      <Button
+                        variant="secondary"
+                        className="w-full"
+                        onClick={handleResendRegistrationEmail}
+                        disabled={isResendingEmail}
+                      >
+                        {isResendingEmail ? 'Se trimite...' : 'Retrimite email de confirmare'}
+                      </Button>
                       {!isPast && (
                         <Button
                           variant="outline"

--- a/ui/src/pages/profile/StudentProfilePage.tsx
+++ b/ui/src/pages/profile/StudentProfilePage.tsx
@@ -158,10 +158,20 @@ export function StudentProfilePage() {
                         : 'border-border hover:border-primary/50'
                     }`}
                     onClick={() => handleTagToggle(tag.id)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleTagToggle(tag.id);
+                      }
+                    }}
                   >
                     <Checkbox
                       id={`tag-${tag.id}`}
                       checked={isSelected}
+                      onClick={(e) => e.stopPropagation()}
+                      onKeyDown={(e) => e.stopPropagation()}
                       onCheckedChange={() => handleTagToggle(tag.id)}
                     />
                     <Label

--- a/ui/src/services/event.service.ts
+++ b/ui/src/services/event.service.ts
@@ -39,8 +39,8 @@ export const eventService = {
   },
 
   async getEventIcs(id: number): Promise<string> {
-    const response = await api.get<string>(`/api/events/${id}/ics`);
-    return response.data;
+    const response = await api.get(`/api/events/${id}/ics`, { responseType: 'text' });
+    return response.data as string;
   },
 
   // Registration endpoints
@@ -77,8 +77,8 @@ export const eventService = {
   },
 
   async getMyCalendar(): Promise<string> {
-    const response = await api.get<string>('/api/me/calendar');
-    return response.data;
+    const response = await api.get('/api/me/calendar', { responseType: 'text' });
+    return response.data as string;
   },
 
   // Recommendations


### PR DESCRIPTION
- **Summary**
  - Wires up several existing backend capabilities that were missing in the current React UI (organizer upgrade, calendar download, resend registration email) and fixes a profile tag selection interaction bug.

- **Changes**
  - Add “Devino organizator” invite-code dialog in the navbar (desktop + mobile) wired to `POST /organizer/upgrade`.
  - Add “Calendar (.ics)” download on “Evenimentele Mele” wired to `GET /api/me/calendar` with auth.
  - Add “Retrimite email de confirmare” for registered events wired to `POST /api/events/{id}/register/resend`.
  - Fix student profile interest tag toggling to avoid double-toggle when clicking the checkbox.
  - Make `eventService.getMyCalendar` / `getEventIcs` explicitly request `text` responses.

- **Testing**
  - `cd ui && npm test` (passes; eslint reports 2 existing `react-hooks/exhaustive-deps` warnings)

- **Risk & Impact**
  - Low. Uses existing backend endpoints; organizer upgrade requires `ORGANIZER_INVITE_CODE` (or equivalent) to be configured server-side.

- **Related TODO items**
  - [x] React UI: add organizer upgrade flow (invite code) wired to `POST /organizer/upgrade`.
  - [x] React UI: add “Resend registration email” action wired to `POST /api/events/{id}/register/resend`.
  - [x] React UI: add “My calendar (.ics)” download wired to `GET /api/me/calendar` (auth required).
  - [x] Fix Student Profile interest tag toggling (avoid double-toggle when clicking the checkbox).
