### PR TITLE
feat: add admin dashboard and moderation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,6 @@ start.bat  # Opens two terminals for backend + frontend
 - `POST /login` - User login (returns access + refresh tokens)
 - `POST /refresh` - Refresh access token
 - `GET /me` - Current user profile
-- `POST /organizer/upgrade` - Upgrade to organizer role
 - `POST /password/forgot` - Request password reset email
 - `POST /password/reset` - Confirm password reset
 
@@ -158,8 +157,8 @@ start.bat  # Opens two terminals for backend + frontend
 - `GET /api/events` - List events (filters: search, category, date_from, date_to, location, tags, skip, limit)
 - `GET /api/events/{id}` - Event details
 - `POST /api/events` - Create event (organizer only)
-- `PUT /api/events/{id}` - Update event (owner only)
-- `DELETE /api/events/{id}` - Delete event (owner only)
+- `PUT /api/events/{id}` - Update event (owner or admin)
+- `DELETE /api/events/{id}` - Delete event (owner or admin)
 - `POST /api/events/{id}/clone` - Clone event (organizer only)
 - `GET /api/events/{id}/ics` - Export event as iCalendar
 
@@ -167,8 +166,14 @@ start.bat  # Opens two terminals for backend + frontend
 - `POST /api/events/{id}/register` - Register for event
 - `POST /api/events/{id}/register/resend` - Resend registration email
 - `DELETE /api/events/{id}/register` - Unregister from event
-- `GET /api/organizer/events/{id}/participants` - List participants (organizer only)
-- `PUT /api/organizer/events/{id}/participants/{user_id}` - Update attendance
+- `GET /api/organizer/events/{id}/participants` - List participants (owner or admin)
+- `PUT /api/organizer/events/{id}/participants/{user_id}` - Update attendance (owner or admin)
+
+### Admin
+- `GET /api/admin/stats` - Summary stats (registrations over time, popular tags)
+- `GET /api/admin/users` - List users + stats
+- `PATCH /api/admin/users/{id}` - Update user role/active flag
+- `GET /api/admin/events` - List events (including unpublished/deleted with filters)
 
 ### User Events
 - `GET /api/me/events` - User's registered events

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Sample credentials:
 
 ## API overview
 
-- Auth: `POST /register`, `POST /login`, `POST /refresh`, `GET /me`, `POST /organizer/upgrade`
+- Auth: `POST /register`, `POST /login`, `POST /refresh`, `GET /me`
 - Events: `GET /api/events` (filters + pagination), `POST /api/events` (organizer),
   `PUT /api/events/{id}`, `DELETE /api/events/{id}` (soft-delete), `POST /api/events/{id}/restore`, `GET /api/events/{id}/ics`
   - Filters include `search`, `category`, `tags_csv`, `start_date`, `end_date`, `location`, `city`, `include_past`, plus paging.
@@ -133,7 +133,8 @@ Sample credentials:
 - Public: `GET /api/public/events`, `GET /api/public/events/{id}` (rate-limited)
 - Profile: `GET /api/me/profile`, `PUT /api/me/profile` (supports `city`, `university`, `faculty`, `study_level`, `study_year`, `interest_tag_ids`)
 - Metadata: `GET /api/metadata/universities` (Romanian university catalog for UI dropdowns)
-- Admin: `POST /api/admin/events/{eventId}/registrations/{userId}/restore`
+- Admin: `GET /api/admin/stats`, `GET /api/admin/users`, `PATCH /api/admin/users/{userId}`, `GET /api/admin/events`,
+  `POST /api/admin/events/{eventId}/registrations/{userId}/restore`
 - Recommendations and search utilities are available under `/api/events` filters, plus calendar
   exports at `/api/me/calendar` for the current user.
 - Docs: Swagger at `/docs`, ReDoc at `/redoc`

--- a/TODO.md
+++ b/TODO.md
@@ -40,6 +40,12 @@
 - [x] Events: add explicit `city` field (separate from `location`) across API + UI.
 - [x] Events: add city filter in event list UI + API.
 - [x] Recommendations: boost events in the user’s city (still include national events).
+- [x] Admin: add DB-backed `admin` role + auth guards (UI + backend).
+- [x] Admin API: event moderation endpoints (list/update/delete/restore any event).
+- [x] Admin API: user management endpoints (list users + stats; change role; deactivate/delete).
+- [x] Admin UI: dashboard for stats + event/user management.
+- [x] Analytics: registrations over time + popular tags (admin dashboard).
+- [x] Remove organizer invite-code upgrade flow (UI + backend); manage organizer role via admin.
 - [ ] Data: expand faculties catalog coverage across all Romanian universities (keep fallback manual input).
 - [x] Events: expand category options in UI (align with seeded categories; add Music and more).
 - [x] Music: add genre tags (rock/pop/etc) to seed data and surface them in profile interests.
@@ -99,7 +105,6 @@
 - [x] UI: tune Vite chunk warning threshold (keep build output clean).
 - [x] Add staging/prod Vite env files with feature flags (e.g., recommendations toggle).
 - [x] Soft-delete support for events and registrations with an audit history.
-- [ ] Admin dashboards for monitoring event stats (registrations over time, popular tags).
 - [x] Public read-only events API with stricter rate limiting for third-party integrations.
 - [x] Searchable filter bar on event list (tags, category, date range, location).
 - [x] Skeleton loaders and optimistic updates for event registration and attendance toggles.

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import Column, MetaData, String, Table, engine_from_config, inspect, pool, text
 
 # add app path
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../')
@@ -21,6 +21,60 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 target_metadata = models.Base.metadata
+
+
+ALEMBIC_VERSION_NUM_LENGTH = 255
+
+
+def ensure_alembic_version_table(connection):
+    inspector = inspect(connection)
+
+    if "alembic_version" not in inspector.get_table_names():
+        metadata = MetaData()
+        Table(
+            "alembic_version",
+            metadata,
+            Column(
+                "version_num",
+                String(ALEMBIC_VERSION_NUM_LENGTH),
+                primary_key=True,
+                nullable=False,
+            ),
+        )
+        metadata.create_all(connection)
+        return
+
+    columns = inspector.get_columns("alembic_version")
+    version_col = next(
+        (column for column in columns if column.get("name") == "version_num"),
+        None,
+    )
+    if version_col is None:
+        return
+
+    col_type = version_col.get("type")
+    length = getattr(col_type, "length", None)
+    if length is None or length >= ALEMBIC_VERSION_NUM_LENGTH:
+        return
+
+    if connection.dialect.name == "postgresql":
+        connection.execute(
+            text(
+                "ALTER TABLE alembic_version "
+                f"ALTER COLUMN version_num TYPE VARCHAR({ALEMBIC_VERSION_NUM_LENGTH})"
+            )
+        )
+        return
+
+    try:
+        connection.execute(
+            text(
+                "ALTER TABLE alembic_version "
+                f"ALTER COLUMN version_num TYPE VARCHAR({ALEMBIC_VERSION_NUM_LENGTH})"
+            )
+        )
+    except Exception:
+        return
 
 
 def run_migrations_offline():
@@ -44,6 +98,8 @@ def run_migrations_online():
     )
 
     with connectable.connect() as connection:
+        with connection.begin():
+            ensure_alembic_version_table(connection)
         context.configure(connection=connection, target_metadata=target_metadata)
 
         with context.begin_transaction():

--- a/backend/alembic/versions/0010_admin_user_mgmt.py
+++ b/backend/alembic/versions/0010_admin_user_mgmt.py
@@ -1,0 +1,45 @@
+"""Add admin role and user stats columns
+
+Revision ID: 0010_admin_user_mgmt
+Revises: 0009_user_academic_event_city
+Create Date: 2025-12-18
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0010_admin_user_mgmt"
+down_revision = "0009_user_academic_event_city"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        # PostgreSQL enum alterations must run outside of a transaction.
+        with op.get_context().autocommit_block():
+            op.execute(sa.text("ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'admin'"))
+
+    op.add_column(
+        "users",
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.add_column(
+        "users",
+        sa.Column("last_seen_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "is_active")
+    op.drop_column("users", "last_seen_at")
+    op.drop_column("users", "created_at")
+
+    # Note: PostgreSQL enum values cannot be removed safely.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,7 +24,6 @@ class Settings(BaseSettings):
     admin_emails: list[str] = []
     auto_create_tables: bool = False
     auto_run_migrations: bool = False
-    organizer_invite_code: str | None = None
     email_enabled: bool = True
     smtp_host: str | None = None
     smtp_port: int | None = None

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -20,6 +20,7 @@ from .database import Base
 class UserRole(str, enum.Enum):
     student = "student"
     organizator = "organizator"
+    admin = "admin"
 
 
 class User(Base):
@@ -29,6 +30,9 @@ class User(Base):
     email = Column(String(255), unique=True, nullable=False)
     password_hash = Column(String(255), nullable=False)
     role = Column(Enum(UserRole), nullable=False)
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+    last_seen_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    is_active = Column(Boolean, nullable=False, server_default="true")
     full_name = Column(String(255))
     org_name = Column(String(255))
     org_description = Column(Text)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -52,11 +52,6 @@ class UserResponse(UserBase):
 
     model_config = ConfigDict(from_attributes=True)
 
-
-class OrganizerUpgradeRequest(BaseModel):
-    invite_code: str
-
-
 class ThemePreferenceUpdate(BaseModel):
     theme_preference: ThemePreference
 
@@ -263,6 +258,79 @@ class StudentProfileUpdate(BaseModel):
     study_level: Optional[StudyLevel] = None
     study_year: Optional[int] = Field(default=None, ge=1, le=10)
     interest_tag_ids: Optional[List[int]] = None
+
+
+class AdminUserUpdate(BaseModel):
+    role: Optional[UserRole] = None
+    is_active: Optional[bool] = None
+
+
+class AdminUserResponse(BaseModel):
+    id: int
+    email: EmailStr
+    role: UserRole
+    full_name: Optional[str] = None
+    org_name: Optional[str] = None
+    created_at: datetime
+    last_seen_at: Optional[datetime] = None
+    is_active: bool
+    registrations_count: int = 0
+    attended_count: int = 0
+    events_created_count: int = 0
+
+
+class PaginatedAdminUsers(BaseModel):
+    items: List[AdminUserResponse]
+    total: int
+    page: int
+    page_size: int
+
+
+class AdminEventResponse(BaseModel):
+    id: int
+    title: str
+    description: Optional[str] = None
+    category: Optional[str] = None
+    start_time: datetime
+    end_time: Optional[datetime] = None
+    city: Optional[str] = None
+    location: Optional[str] = None
+    max_seats: Optional[int] = None
+    cover_url: Optional[str] = None
+    owner_id: int
+    owner_email: EmailStr
+    owner_name: Optional[str] = None
+    tags: List[TagResponse] = []
+    seats_taken: int = 0
+    status: Optional[str] = None
+    publish_at: Optional[datetime] = None
+    deleted_at: Optional[datetime] = None
+
+
+class PaginatedAdminEvents(BaseModel):
+    items: List[AdminEventResponse]
+    total: int
+    page: int
+    page_size: int
+
+
+class RegistrationDayStat(BaseModel):
+    date: str
+    registrations: int
+
+
+class TagPopularityStat(BaseModel):
+    name: str
+    registrations: int
+    events: int
+
+
+class AdminStatsResponse(BaseModel):
+    total_users: int
+    total_events: int
+    total_registrations: int
+    registrations_by_day: List[RegistrationDayStat]
+    top_tags: List[TagPopularityStat]
 
 
 class PasswordResetRequest(BaseModel):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -67,6 +67,15 @@ def helpers(client, db_session):
         db_session.add(organizer)
         db_session.commit()
 
+    def make_admin(email: str = "admin@test.ro", password: str = "admin123") -> None:
+        admin = models.User(
+            email=email,
+            password_hash=auth.get_password_hash(password),
+            role=models.UserRole.admin,
+        )
+        db_session.add(admin)
+        db_session.commit()
+
     def future_time(days: int = 1) -> str:
         return (datetime.now(timezone.utc) + timedelta(days=days)).isoformat()
 
@@ -79,7 +88,7 @@ def helpers(client, db_session):
         "register_student": register_student,
         "login": login,
         "make_organizer": make_organizer,
+        "make_admin": make_admin,
         "future_time": future_time,
         "auth_header": auth_header,
     }
-

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,23 +1,23 @@
 # Role-based permissions
 
-The platform has two roles: **student** and **organizer**. Requests without a valid JWT receive `401 Unauthorized`. Requests with a JWT for the wrong role receive `403 Forbidden`.
+The platform has three roles: **student**, **organizer**, and **admin**. Requests without a valid JWT receive `401 Unauthorized`. Requests with a JWT for the wrong role receive `403 Forbidden`.
 
 ## Matrix
-| Action | Endpoint(s) | Student | Organizer |
-| --- | --- | --- | --- |
-| Browse events | `GET /api/events`, `GET /api/events/{id}` | ✅ | ✅ |
-| Register/unregister | `POST/DELETE /api/events/{id}/register` | ✅ (self) | ❌ |
-| Resend registration email | `POST /api/events/{id}/register/resend` | ✅ (self) | ❌ |
-| Create/edit/delete event | `POST/PUT/DELETE /api/events` | ❌ | ✅ (own events only) |
-| Clone event | `POST /api/events/{id}/clone` | ❌ | ✅ (own events only) |
-| View own created events | `GET /api/organizer/events` | ❌ | ✅ |
-| View participants / mark attendance | `GET/PUT /api/organizer/events/{id}/participants` | ❌ | ✅ (owner only) |
-| Recommendations | `GET /api/recommendations` | ✅ | ✅ |
-| My events feed | `GET /api/me/events`, `GET /api/me/calendar` | ✅ | ❌ |
-| Favorites | `GET /api/me/favorites`, `POST/DELETE /api/events/{id}/favorite` | ✅ (self) | ❌ |
-| Export my data | `GET /api/me/export` | ✅ (self) | ✅ (self) |
-| Delete my account | `DELETE /api/me` | ✅ (self) | ✅ (self) |
-| Upgrade to organizer | `POST /organizer/upgrade` | ✅ | ✅ (no-op) |
-| Health check | `GET /api/health` | ✅ | ✅ |
+| Action | Endpoint(s) | Student | Organizer | Admin |
+| --- | --- | --- | --- | --- |
+| Browse events | `GET /api/events`, `GET /api/events/{id}` | ✅ | ✅ | ✅ |
+| Register/unregister | `POST/DELETE /api/events/{id}/register` | ✅ (self) | ❌ | ❌ |
+| Resend registration email | `POST /api/events/{id}/register/resend` | ✅ (self) | ❌ | ❌ |
+| Create/edit/delete event | `POST/PUT/DELETE /api/events` | ❌ | ✅ (own events only) | ✅ (any event) |
+| Clone event | `POST /api/events/{id}/clone` | ❌ | ✅ (own events only) | ✅ (own events only) |
+| View own created events | `GET /api/organizer/events` | ❌ | ✅ | ✅ (own events only) |
+| View participants / mark attendance | `GET/PUT /api/organizer/events/{id}/participants` | ❌ | ✅ (owner only) | ✅ (any event) |
+| Admin dashboard | `GET /api/admin/stats`, `GET/PATCH /api/admin/users`, `GET /api/admin/events` | ❌ | ❌ | ✅ |
+| Recommendations | `GET /api/recommendations` | ✅ | ✅ | ✅ |
+| My events feed | `GET /api/me/events`, `GET /api/me/calendar` | ✅ | ❌ | ❌ |
+| Favorites | `GET /api/me/favorites`, `POST/DELETE /api/events/{id}/favorite` | ✅ (self) | ❌ | ❌ |
+| Export my data | `GET /api/me/export` | ✅ (self) | ✅ (self) | ✅ (self) |
+| Delete my account | `DELETE /api/me` | ✅ (self) | ✅ (self) | ✅ (self) |
+| Health check | `GET /api/health` | ✅ | ✅ | ✅ |
 
 Ownership rules apply where noted (organizers can only modify their own events and participants). Tests in `backend/tests/test_permissions.py` assert these behaviors.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,6 +19,9 @@ import { StudentProfilePage } from '@/pages/profile';
 import { ForbiddenPage } from '@/pages/ForbiddenPage';
 import { NotFoundPage } from '@/pages/NotFoundPage';
 
+// Admin pages
+import { AdminDashboardPage } from '@/pages/admin';
+
 // Organizer pages
 import {
   OrganizerDashboardPage,
@@ -55,6 +58,25 @@ function OrganizerRoute({ children }: { children: React.ReactNode }) {
   }
 
   if (!isOrganizer) {
+    return <Navigate to="/forbidden" replace />;
+  }
+
+  return <>{children}</>;
+}
+
+// Admin route wrapper
+function AdminRoute({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, isAdmin, isLoading } = useAuth();
+
+  if (isLoading) {
+    return <LoadingPage />;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (!isAdmin) {
     return <Navigate to="/forbidden" replace />;
   }
 
@@ -143,6 +165,16 @@ function AppRoutes() {
             <OrganizerRoute>
               <ParticipantsPage />
             </OrganizerRoute>
+          }
+        />
+
+        {/* Admin routes */}
+        <Route
+          path="/admin"
+          element={
+            <AdminRoute>
+              <AdminDashboardPage />
+            </AdminRoute>
           }
         />
 

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -7,6 +7,7 @@ interface AuthContextType {
   user: User | null;
   isAuthenticated: boolean;
   isOrganizer: boolean;
+  isAdmin: boolean;
   isLoading: boolean;
   login: (email: string, password: string) => Promise<void>;
   register: (email: string, password: string, confirmPassword: string, fullName?: string) => Promise<void>;
@@ -69,7 +70,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       value={{
         user,
         isAuthenticated: !!user,
-        isOrganizer: user?.role === 'organizator',
+        isOrganizer: user?.role === 'organizator' || user?.role === 'admin',
+        isAdmin: user?.role === 'admin',
         isLoading,
         login,
         register,

--- a/ui/src/pages/admin/AdminDashboardPage.tsx
+++ b/ui/src/pages/admin/AdminDashboardPage.tsx
@@ -1,0 +1,596 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import adminService from '@/services/admin.service';
+import eventService from '@/services/event.service';
+import { useToast } from '@/hooks/use-toast';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { LoadingPage } from '@/components/ui/loading';
+import type { AdminEvent, AdminStats, AdminUser, UserRole } from '@/types';
+import { formatDateTime } from '@/lib/utils';
+import { Edit, RefreshCw, RotateCcw, Trash2 } from 'lucide-react';
+
+type AdminTab = 'overview' | 'users' | 'events';
+
+function roleBadgeVariant(role: UserRole): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (role === 'admin') return 'destructive';
+  if (role === 'organizator') return 'secondary';
+  return 'outline';
+}
+
+export function AdminDashboardPage() {
+  const { toast } = useToast();
+  const [tab, setTab] = useState<AdminTab>('overview');
+
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [isLoadingStats, setIsLoadingStats] = useState(false);
+
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [usersTotal, setUsersTotal] = useState(0);
+  const [usersPage, setUsersPage] = useState(1);
+  const [usersPageSize] = useState(20);
+  const [usersSearch, setUsersSearch] = useState('');
+  const [usersRole, setUsersRole] = useState<'all' | UserRole>('all');
+  const [usersActive, setUsersActive] = useState<'all' | 'active' | 'inactive'>('all');
+  const [isLoadingUsers, setIsLoadingUsers] = useState(false);
+
+  const [events, setEvents] = useState<AdminEvent[]>([]);
+  const [eventsTotal, setEventsTotal] = useState(0);
+  const [eventsPage, setEventsPage] = useState(1);
+  const [eventsPageSize] = useState(20);
+  const [eventsSearch, setEventsSearch] = useState('');
+  const [eventsStatus, setEventsStatus] = useState<'all' | 'draft' | 'published'>('all');
+  const [eventsIncludeDeleted, setEventsIncludeDeleted] = useState(false);
+  const [isLoadingEvents, setIsLoadingEvents] = useState(false);
+
+  const loadStats = useCallback(async () => {
+    setIsLoadingStats(true);
+    try {
+      const data = await adminService.getStats();
+      setStats(data);
+    } catch {
+      toast({
+        title: 'Eroare',
+        description: 'Nu am putut încărca statisticile admin.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsLoadingStats(false);
+    }
+  }, [toast]);
+
+  const loadUsers = useCallback(
+    async (page = usersPage) => {
+      setIsLoadingUsers(true);
+      try {
+        const data = await adminService.getUsers({
+          search: usersSearch || undefined,
+          role: usersRole === 'all' ? undefined : usersRole,
+          is_active:
+            usersActive === 'all' ? undefined : usersActive === 'active',
+          page,
+          page_size: usersPageSize,
+        });
+        setUsers(data.items);
+        setUsersTotal(data.total);
+        setUsersPage(data.page);
+      } catch {
+        toast({
+          title: 'Eroare',
+          description: 'Nu am putut încărca utilizatorii.',
+          variant: 'destructive',
+        });
+      } finally {
+        setIsLoadingUsers(false);
+      }
+    },
+    [toast, usersActive, usersPage, usersPageSize, usersRole, usersSearch],
+  );
+
+  const loadEvents = useCallback(
+    async (page = eventsPage) => {
+      setIsLoadingEvents(true);
+      try {
+        const data = await adminService.getEvents({
+          search: eventsSearch || undefined,
+          status: eventsStatus === 'all' ? undefined : eventsStatus,
+          include_deleted: eventsIncludeDeleted || undefined,
+          page,
+          page_size: eventsPageSize,
+        });
+        setEvents(data.items);
+        setEventsTotal(data.total);
+        setEventsPage(data.page);
+      } catch {
+        toast({
+          title: 'Eroare',
+          description: 'Nu am putut încărca evenimentele.',
+          variant: 'destructive',
+        });
+      } finally {
+        setIsLoadingEvents(false);
+      }
+    },
+    [eventsIncludeDeleted, eventsPage, eventsPageSize, eventsSearch, eventsStatus, toast],
+  );
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
+  useEffect(() => {
+    if (tab === 'users') {
+      loadUsers(1);
+    }
+    if (tab === 'events') {
+      loadEvents(1);
+    }
+  }, [tab, loadEvents, loadUsers]);
+
+  const totalUserPages = useMemo(
+    () => Math.max(1, Math.ceil(usersTotal / usersPageSize)),
+    [usersPageSize, usersTotal],
+  );
+  const totalEventPages = useMemo(
+    () => Math.max(1, Math.ceil(eventsTotal / eventsPageSize)),
+    [eventsPageSize, eventsTotal],
+  );
+
+  const handleUpdateUser = async (userId: number, patch: Partial<Pick<AdminUser, 'role' | 'is_active'>>) => {
+    const prev = users;
+    setUsers((current) =>
+      current.map((u) => (u.id === userId ? { ...u, ...patch } : u)),
+    );
+    try {
+      const updated = await adminService.updateUser(userId, patch);
+      setUsers((current) => current.map((u) => (u.id === userId ? updated : u)));
+      toast({ title: 'Salvat', description: 'Utilizator actualizat.' });
+    } catch {
+      setUsers(prev);
+      toast({
+        title: 'Eroare',
+        description: 'Nu am putut actualiza utilizatorul.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleDeleteEvent = async (eventId: number) => {
+    if (!confirm('Ștergi acest eveniment?')) return;
+    try {
+      await eventService.deleteEvent(eventId);
+      toast({ title: 'Succes', description: 'Eveniment șters.' });
+      await loadEvents(eventsPage);
+    } catch {
+      toast({
+        title: 'Eroare',
+        description: 'Nu am putut șterge evenimentul.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleRestoreEvent = async (eventId: number) => {
+    try {
+      await eventService.restoreEvent(eventId);
+      toast({ title: 'Succes', description: 'Eveniment restaurat.' });
+      await loadEvents(eventsPage);
+    } catch {
+      toast({
+        title: 'Eroare',
+        description: 'Nu am putut restaura evenimentul.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  if (!stats && isLoadingStats) {
+    return <LoadingPage message="Se încarcă dashboard-ul admin..." />;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+          <p className="mt-2 text-muted-foreground">Monitorizare și management platformă</p>
+        </div>
+        <Button variant="outline" onClick={() => loadStats()} disabled={isLoadingStats}>
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Reîncarcă
+        </Button>
+      </div>
+
+      <Tabs value={tab} onValueChange={(value) => setTab(value as AdminTab)}>
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="users">Utilizatori</TabsTrigger>
+          <TabsTrigger value="events">Evenimente</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="mt-6 space-y-6">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium">Total utilizatori</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{stats?.total_users ?? 0}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium">Total evenimente</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{stats?.total_events ?? 0}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium">Total înscrieri</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{stats?.total_registrations ?? 0}</div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Înscrieri pe zile</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {!stats?.registrations_by_day?.length ? (
+                  <p className="text-sm text-muted-foreground">Nu există date încă.</p>
+                ) : (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Zi</TableHead>
+                        <TableHead className="text-right">Înscrieri</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {stats.registrations_by_day.slice(-14).map((row) => (
+                        <TableRow key={row.date}>
+                          <TableCell>{row.date}</TableCell>
+                          <TableCell className="text-right">{row.registrations}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Top taguri</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {!stats?.top_tags?.length ? (
+                  <p className="text-sm text-muted-foreground">Nu există date încă.</p>
+                ) : (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Tag</TableHead>
+                        <TableHead className="text-right">Înscrieri</TableHead>
+                        <TableHead className="text-right">Evenimente</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {stats.top_tags.map((row) => (
+                        <TableRow key={row.name}>
+                          <TableCell>{row.name}</TableCell>
+                          <TableCell className="text-right">{row.registrations}</TableCell>
+                          <TableCell className="text-right">{row.events}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="users" className="mt-6 space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Utilizatori</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-end">
+                <div className="flex-1">
+                  <label className="mb-1 block text-sm font-medium">Caută</label>
+                  <Input value={usersSearch} onChange={(e) => setUsersSearch(e.target.value)} placeholder="email / nume" />
+                </div>
+                <div className="w-full md:w-56">
+                  <label className="mb-1 block text-sm font-medium">Rol</label>
+                  <Select value={usersRole} onValueChange={(v) => setUsersRole(v as 'all' | UserRole)}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Toate" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">Toate</SelectItem>
+                      <SelectItem value="student">Student</SelectItem>
+                      <SelectItem value="organizator">Organizator</SelectItem>
+                      <SelectItem value="admin">Admin</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="w-full md:w-56">
+                  <label className="mb-1 block text-sm font-medium">Status</label>
+                  <Select value={usersActive} onValueChange={(v) => setUsersActive(v as 'all' | 'active' | 'inactive')}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Toate" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">Toate</SelectItem>
+                      <SelectItem value="active">Active</SelectItem>
+                      <SelectItem value="inactive">Dezactivate</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button onClick={() => loadUsers(1)} disabled={isLoadingUsers}>
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                  Aplică
+                </Button>
+              </div>
+
+              {isLoadingUsers ? (
+                <LoadingPage message="Se încarcă utilizatorii..." />
+              ) : users.length === 0 ? (
+                <p className="text-sm text-muted-foreground">Niciun utilizator găsit.</p>
+              ) : (
+                <>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Email</TableHead>
+                        <TableHead>Rol</TableHead>
+                        <TableHead>Activ</TableHead>
+                        <TableHead>Creat</TableHead>
+                        <TableHead>Ultima activitate</TableHead>
+                        <TableHead className="text-right">Înscrieri</TableHead>
+                        <TableHead className="text-right">Prezențe</TableHead>
+                        <TableHead className="text-right">Evenimente</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {users.map((u) => (
+                        <TableRow key={u.id}>
+                          <TableCell>
+                            <div className="font-medium">{u.email}</div>
+                            {u.full_name && <div className="text-xs text-muted-foreground">{u.full_name}</div>}
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex items-center gap-2">
+                              <Badge variant={roleBadgeVariant(u.role)}>{u.role}</Badge>
+                              <Select
+                                value={u.role}
+                                onValueChange={(value) =>
+                                  handleUpdateUser(u.id, { role: value as UserRole })
+                                }
+                              >
+                                <SelectTrigger className="h-8 w-[150px]">
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="student">Student</SelectItem>
+                                  <SelectItem value="organizator">Organizator</SelectItem>
+                                  <SelectItem value="admin">Admin</SelectItem>
+                                </SelectContent>
+                              </Select>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <Checkbox
+                              checked={u.is_active}
+                              onCheckedChange={(checked) =>
+                                handleUpdateUser(u.id, { is_active: Boolean(checked) })
+                              }
+                            />
+                          </TableCell>
+                          <TableCell>{formatDateTime(u.created_at)}</TableCell>
+                          <TableCell>{u.last_seen_at ? formatDateTime(u.last_seen_at) : '-'}</TableCell>
+                          <TableCell className="text-right">{u.registrations_count}</TableCell>
+                          <TableCell className="text-right">{u.attended_count}</TableCell>
+                          <TableCell className="text-right">{u.events_created_count}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+
+                  <div className="mt-4 flex items-center justify-between">
+                    <p className="text-sm text-muted-foreground">
+                      Pagina {usersPage} / {totalUserPages} • Total {usersTotal}
+                    </p>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={usersPage <= 1}
+                        onClick={() => loadUsers(usersPage - 1)}
+                      >
+                        Înapoi
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={usersPage >= totalUserPages}
+                        onClick={() => loadUsers(usersPage + 1)}
+                      >
+                        Înainte
+                      </Button>
+                    </div>
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="events" className="mt-6 space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Evenimente</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-end">
+                <div className="flex-1">
+                  <label className="mb-1 block text-sm font-medium">Caută</label>
+                  <Input value={eventsSearch} onChange={(e) => setEventsSearch(e.target.value)} placeholder="titlu / owner" />
+                </div>
+                <div className="w-full md:w-56">
+                  <label className="mb-1 block text-sm font-medium">Status</label>
+                  <Select value={eventsStatus} onValueChange={(v) => setEventsStatus(v as 'all' | 'draft' | 'published')}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Toate" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">Toate</SelectItem>
+                      <SelectItem value="published">Published</SelectItem>
+                      <SelectItem value="draft">Draft</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    checked={eventsIncludeDeleted}
+                    onCheckedChange={(checked) => setEventsIncludeDeleted(Boolean(checked))}
+                  />
+                  <span className="text-sm">Include șterse</span>
+                </div>
+                <Button onClick={() => loadEvents(1)} disabled={isLoadingEvents}>
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                  Aplică
+                </Button>
+              </div>
+
+              {isLoadingEvents ? (
+                <LoadingPage message="Se încarcă evenimentele..." />
+              ) : events.length === 0 ? (
+                <p className="text-sm text-muted-foreground">Niciun eveniment găsit.</p>
+              ) : (
+                <>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Titlu</TableHead>
+                        <TableHead>Oraș</TableHead>
+                        <TableHead>Dată</TableHead>
+                        <TableHead>Owner</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className="text-right">Locuri</TableHead>
+                        <TableHead className="w-[160px]"></TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {events.map((e) => {
+                        const deleted = Boolean(e.deleted_at);
+                        return (
+                          <TableRow key={e.id} className={deleted ? 'opacity-70' : undefined}>
+                            <TableCell>
+                              <Link to={`/events/${e.id}`} className="font-medium hover:underline">
+                                {e.title}
+                              </Link>
+                              {deleted && (
+                                <Badge className="ml-2" variant="destructive">
+                                  deleted
+                                </Badge>
+                              )}
+                            </TableCell>
+                            <TableCell>{e.city || '-'}</TableCell>
+                            <TableCell>{formatDateTime(e.start_time)}</TableCell>
+                            <TableCell>
+                              <div className="text-sm">{e.owner_email}</div>
+                              {e.owner_name && (
+                                <div className="text-xs text-muted-foreground">{e.owner_name}</div>
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant={e.status === 'draft' ? 'secondary' : 'default'}>
+                                {e.status || 'published'}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="text-right">
+                              {e.seats_taken}/{e.max_seats ?? '-'}
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <div className="flex justify-end gap-2">
+                                <Button asChild variant="outline" size="sm" disabled={deleted}>
+                                  <Link to={`/organizer/events/${e.id}/edit`}>
+                                    <Edit className="mr-2 h-4 w-4" />
+                                    Edit
+                                  </Link>
+                                </Button>
+                                {deleted ? (
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => handleRestoreEvent(e.id)}
+                                  >
+                                    <RotateCcw className="mr-2 h-4 w-4" />
+                                    Restore
+                                  </Button>
+                                ) : (
+                                  <Button
+                                    variant="destructive"
+                                    size="sm"
+                                    onClick={() => handleDeleteEvent(e.id)}
+                                  >
+                                    <Trash2 className="mr-2 h-4 w-4" />
+                                    Delete
+                                  </Button>
+                                )}
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+
+                  <div className="mt-4 flex items-center justify-between">
+                    <p className="text-sm text-muted-foreground">
+                      Pagina {eventsPage} / {totalEventPages} • Total {eventsTotal}
+                    </p>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={eventsPage <= 1}
+                        onClick={() => loadEvents(eventsPage - 1)}
+                      >
+                        Înapoi
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={eventsPage >= totalEventPages}
+                        onClick={() => loadEvents(eventsPage + 1)}
+                      >
+                        Înainte
+                      </Button>
+                    </div>
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+

--- a/ui/src/pages/admin/index.ts
+++ b/ui/src/pages/admin/index.ts
@@ -1,0 +1,2 @@
+export { AdminDashboardPage } from './AdminDashboardPage';
+

--- a/ui/src/services/admin.service.ts
+++ b/ui/src/services/admin.service.ts
@@ -1,0 +1,68 @@
+import api from './api';
+import type {
+  AdminStats,
+  AdminUser,
+  AdminUserUpdate,
+  PaginatedAdminEvents,
+  PaginatedAdminUsers,
+  UserRole,
+} from '../types';
+
+export interface AdminUsersFilters {
+  search?: string;
+  role?: UserRole;
+  is_active?: boolean;
+  page?: number;
+  page_size?: number;
+}
+
+export interface AdminEventsFilters {
+  search?: string;
+  category?: string;
+  city?: string;
+  status?: 'draft' | 'published';
+  include_deleted?: boolean;
+  page?: number;
+  page_size?: number;
+}
+
+export const adminService = {
+  async getStats(days = 30, topTagsLimit = 10): Promise<AdminStats> {
+    const params = new URLSearchParams();
+    params.append('days', days.toString());
+    params.append('top_tags_limit', topTagsLimit.toString());
+    const response = await api.get<AdminStats>(`/api/admin/stats?${params.toString()}`);
+    return response.data;
+  },
+
+  async getUsers(filters: AdminUsersFilters = {}): Promise<PaginatedAdminUsers> {
+    const params = new URLSearchParams();
+    if (filters.search) params.append('search', filters.search);
+    if (filters.role) params.append('role', filters.role);
+    if (filters.is_active !== undefined) params.append('is_active', String(filters.is_active));
+    if (filters.page) params.append('page', filters.page.toString());
+    if (filters.page_size) params.append('page_size', filters.page_size.toString());
+    const response = await api.get<PaginatedAdminUsers>(`/api/admin/users?${params.toString()}`);
+    return response.data;
+  },
+
+  async updateUser(userId: number, payload: AdminUserUpdate): Promise<AdminUser> {
+    const response = await api.patch<AdminUser>(`/api/admin/users/${userId}`, payload);
+    return response.data;
+  },
+
+  async getEvents(filters: AdminEventsFilters = {}): Promise<PaginatedAdminEvents> {
+    const params = new URLSearchParams();
+    if (filters.search) params.append('search', filters.search);
+    if (filters.category) params.append('category', filters.category);
+    if (filters.city) params.append('city', filters.city);
+    if (filters.status) params.append('status', filters.status);
+    if (filters.include_deleted) params.append('include_deleted', 'true');
+    if (filters.page) params.append('page', filters.page.toString());
+    if (filters.page_size) params.append('page_size', filters.page_size.toString());
+    const response = await api.get<PaginatedAdminEvents>(`/api/admin/events?${params.toString()}`);
+    return response.data;
+  },
+};
+
+export default adminService;

--- a/ui/src/services/auth.service.ts
+++ b/ui/src/services/auth.service.ts
@@ -36,11 +36,6 @@ export const authService = {
     return response.data;
   },
 
-  async upgradeToOrganizer(inviteCode: string): Promise<{ status: string }> {
-    const response = await api.post('/organizer/upgrade', { invite_code: inviteCode });
-    return response.data;
-  },
-
   async requestPasswordReset(email: string): Promise<void> {
     await api.post('/password/forgot', { email });
   },
@@ -81,7 +76,7 @@ export const authService = {
 
   isOrganizer(): boolean {
     const user = this.getStoredUser();
-    return user?.role === 'organizator';
+    return user?.role === 'organizator' || user?.role === 'admin';
   },
 };
 

--- a/ui/src/services/event.service.ts
+++ b/ui/src/services/event.service.ts
@@ -114,6 +114,11 @@ export const eventService = {
     await api.delete(`/api/events/${id}`);
   },
 
+  async restoreEvent(id: number): Promise<{ status: string; restored_registrations?: number }> {
+    const response = await api.post(`/api/events/${id}/restore`);
+    return response.data as { status: string; restored_registrations?: number };
+  },
+
   async cloneEvent(id: number): Promise<Event> {
     const response = await api.post<Event>(`/api/events/${id}/clone`);
     return response.data;

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -1,4 +1,4 @@
-export type UserRole = 'student' | 'organizator';
+export type UserRole = 'student' | 'organizator' | 'admin';
 export type ThemePreference = 'system' | 'light' | 'dark';
 export type StudyLevel = 'bachelor' | 'master' | 'phd' | 'medicine';
 
@@ -143,4 +143,77 @@ export interface UniversityCatalogItem {
   name: string;
   city?: string | null;
   faculties: string[];
+}
+
+export interface RegistrationDayStat {
+  date: string;
+  registrations: number;
+}
+
+export interface TagPopularityStat {
+  name: string;
+  registrations: number;
+  events: number;
+}
+
+export interface AdminStats {
+  total_users: number;
+  total_events: number;
+  total_registrations: number;
+  registrations_by_day: RegistrationDayStat[];
+  top_tags: TagPopularityStat[];
+}
+
+export interface AdminUser {
+  id: number;
+  email: string;
+  role: UserRole;
+  full_name?: string | null;
+  org_name?: string | null;
+  created_at: string;
+  last_seen_at?: string | null;
+  is_active: boolean;
+  registrations_count: number;
+  attended_count: number;
+  events_created_count: number;
+}
+
+export interface PaginatedAdminUsers {
+  items: AdminUser[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+export interface AdminUserUpdate {
+  role?: UserRole;
+  is_active?: boolean;
+}
+
+export interface AdminEvent {
+  id: number;
+  title: string;
+  description?: string | null;
+  category?: string | null;
+  start_time: string;
+  end_time?: string | null;
+  city?: string | null;
+  location?: string | null;
+  max_seats?: number | null;
+  cover_url?: string | null;
+  owner_id: number;
+  owner_email: string;
+  owner_name?: string | null;
+  tags: Tag[];
+  seats_taken: number;
+  status?: string | null;
+  publish_at?: string | null;
+  deleted_at?: string | null;
+}
+
+export interface PaginatedAdminEvents {
+  items: AdminEvent[];
+  total: number;
+  page: number;
+  page_size: number;
 }


### PR DESCRIPTION
- **Summary**
  - Adds an admin role + admin dashboard to manage users/events and view platform stats.
  - Removes the invite-code organizer upgrade flow in favor of admin-managed role changes.

- **Changes**
  - Backend: added `admin` role, user activity fields (`created_at`, `last_seen_at`, `is_active`), and admin endpoints for stats/users/events.
  - Backend: allow admins to update/delete events and access participants/attendance for any event.
  - UI: added `/admin` dashboard (stats + users/events management) and admin nav link.
  - Docs: updated API/permissions docs to reflect admin + removal of `/organizer/upgrade`.
  - Docker/CI: fixed Alembic enum migration autocommit + ensured version table is compatible.

- **Testing**
  - `cd backend && pytest` (pass)
  - `cd ui && npm test` (pass)
  - `docker compose up -d --build` and `curl http://localhost:8000/api/health` (pass)

- **Risk & Impact**
  - DB migration adds a new Postgres enum value (`admin`) and new columns on `users`.
  - Breaking change: removed `POST /organizer/upgrade`; clients should use admin role management instead.

- **Related TODO items**
  - [x] Admin: add DB-backed `admin` role + auth guards (UI + backend).
  - [x] Admin API: event moderation endpoints (list/update/delete/restore any event).
  - [x] Admin API: user management endpoints (list users + stats; change role; deactivate/delete).
  - [x] Admin UI: dashboard for stats + event/user management.
  - [x] Analytics: registrations over time + popular tags (admin dashboard).
  - [x] Remove organizer invite-code upgrade flow (UI + backend); manage organizer role via admin.
