### PR TITLE
feat: normalize university names and aliases

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,7 @@
 - [x] Remove organizer invite-code upgrade flow (UI + backend); manage organizer role via admin.
 - [x] Data: expand faculties catalog coverage across all Romanian universities (keep fallback manual input).
 - [x] Data: fill the remaining missing faculty lists (private/specialized institutions) or remove obsolete entries.
-- [ ] Data: normalize/alias university names (fix typos like `Transilvany`, `Oil- Gas`, and handle legacy values).
+- [x] Data: normalize/alias university names (fix typos like `Transilvany`, `Oil- Gas`, and handle legacy values).
 - [x] Events: expand category options in UI (align with seeded categories; add Music and more).
 - [x] Music: add genre tags (rock/pop/etc) to seed data and surface them in profile interests.
 - [x] Recommendations: include profile interest tags (cold-start) when building suggestions.

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -1032,7 +1032,7 @@ def get_student_profile(
         "email": current_user.email,
         "full_name": current_user.full_name,
         "city": current_user.city,
-        "university": current_user.university,
+        "university": ro_universities.normalize_university_name(current_user.university),
         "faculty": current_user.faculty,
         "study_level": current_user.study_level,
         "study_year": current_user.study_year,
@@ -1053,7 +1053,7 @@ def update_student_profile(
     if payload.city is not None:
         current_user.city = payload.city.strip() or None
     if payload.university is not None:
-        current_user.university = payload.university.strip() or None
+        current_user.university = ro_universities.normalize_university_name(payload.university)
     if payload.faculty is not None:
         current_user.faculty = payload.faculty.strip() or None
     if payload.study_level is not None:
@@ -1083,7 +1083,7 @@ def update_student_profile(
         "email": current_user.email,
         "full_name": current_user.full_name,
         "city": current_user.city,
-        "university": current_user.university,
+        "university": ro_universities.normalize_university_name(current_user.university),
         "faculty": current_user.faculty,
         "study_level": current_user.study_level,
         "study_year": current_user.study_year,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -232,6 +232,7 @@ class UniversityCatalogItem(BaseModel):
     name: str
     city: Optional[str] = None
     faculties: List[str] = Field(default_factory=list)
+    aliases: List[str] = Field(default_factory=list)
 
 
 class UniversityCatalogResponse(BaseModel):

--- a/backend/tests/test_ro_universities.py
+++ b/backend/tests/test_ro_universities.py
@@ -1,0 +1,22 @@
+from app import ro_universities
+
+
+def test_normalize_university_name_handles_none_and_empty():
+    assert ro_universities.normalize_university_name(None) is None
+    assert ro_universities.normalize_university_name("") is None
+    assert ro_universities.normalize_university_name("   ") is None
+
+
+def test_normalize_university_name_aliases_legacy_typos():
+    assert (
+        ro_universities.normalize_university_name(' University "Transilvany" of Brasov ')
+        == 'University "Transilvania" of Brasov'
+    )
+    assert ro_universities.normalize_university_name("University Oil- Gas Ploiesti") == "University Oil-Gas Ploiesti"
+    assert ro_universities.normalize_university_name("University Oil - Gas Ploiesti") == "University Oil-Gas Ploiesti"
+
+
+def test_university_catalog_includes_aliases():
+    items = ro_universities.get_university_catalog()
+    transilvania = next(item for item in items if item["name"] == 'University "Transilvania" of Brasov')
+    assert 'University "Transilvany" of Brasov' in transilvania["aliases"]

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -143,6 +143,7 @@ export interface UniversityCatalogItem {
   name: string;
   city?: string | null;
   faculties: string[];
+  aliases?: string[];
 }
 
 export interface RegistrationDayStat {


### PR DESCRIPTION
- **Summary**
  - Canonicalizes Romanian university names (including legacy typo variants) and ensures the student profile API returns/stores the canonical value.
- **Changes**
  - Add university name normalization + alias mapping and expose `aliases` in `/api/metadata/universities`.
  - Normalize `university` in `GET /api/me/profile` and `PUT /api/me/profile` so legacy stored values are surfaced consistently.
  - Add backend unit tests for alias normalization.
  - Update UI `UniversityCatalogItem` type to allow `aliases`.
- **Testing**
  - `cd backend && pytest` (pass)
- **Risk & Impact**
  - Low risk; backward compatible. Existing DB values are not migrated, but are normalized on read and new writes are stored canonical.
- **Related TODO items**
  - `- [x] Data: normalize/alias university names (fix typos like `Transilvany`, `Oil- Gas`, and handle legacy values).`