### PR TITLE
chore: add coverage reporting and Postgres integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,13 @@ jobs:
       - name: Run backend tests
         run: |
           cd backend
-          pytest
+          pytest --cov-report=xml:coverage.xml --cov-fail-under=70
+      - name: Upload backend coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: backend/coverage.xml
+          if-no-files-found: error
 
   frontend:
     runs-on: ubuntu-latest
@@ -53,6 +59,55 @@ jobs:
         run: |
           cd ui
           npm test
+      - name: Upload frontend coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: ui/coverage
+          if-no-files-found: error
+
+  backend-integration:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: eventlink_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d eventlink_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('backend/requirements.txt') }}
+          restore-keys: |
+            pip-
+      - name: Install backend deps
+        run: |
+          cd backend
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run Postgres integration tests
+        env:
+          DATABASE_URL: postgresql+psycopg2://postgres:postgres@localhost:5432/eventlink_test
+          SECRET_KEY: integration-test-secret
+          EMAIL_ENABLED: "false"
+          RUN_INTEGRATION_TESTS: "1"
+        run: |
+          cd backend
+          pytest integration_tests
 
   docker-compose:
     runs-on: ubuntu-latest

--- a/TODO.md
+++ b/TODO.md
@@ -119,8 +119,8 @@
 - [x] Recommendation explanation in UI ("Because you attended X" / "Similar tags: Y").
 - [x] Add restore endpoints for soft-deleted events/registrations (organizer/admin).
 - [x] Pre-commit hooks for formatting (black/ruff for Python, prettier/eslint for UI).
-- [ ] Coverage reporting for backend/frontend with minimum thresholds in CI.
-- [ ] Integration tests hitting a real test database (not just unit tests).
+- [x] Coverage reporting for backend/frontend with minimum thresholds in CI.
+- [x] Integration tests hitting a real test database (not just unit tests).
 - [x] Contract tests around API schema to keep UI and backend in sync.
 - [x] Bulk operations for organizers (bulk email registrants, bulk close events, bulk tag edits).
 - [x] "Favorite events" / "watchlist" feature for students.

--- a/backend/integration_tests/conftest.py
+++ b/backend/integration_tests/conftest.py
@@ -1,0 +1,102 @@
+import os
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+
+if os.environ.get("RUN_INTEGRATION_TESTS") != "1":
+    pytest.skip(
+        "Integration tests are disabled. Set RUN_INTEGRATION_TESTS=1 to enable.",
+        allow_module_level=True,
+    )
+
+if not os.environ.get("DATABASE_URL"):
+    pytest.skip("DATABASE_URL must be set for integration tests.", allow_module_level=True)
+
+os.environ.setdefault("SECRET_KEY", "integration-test-secret")
+os.environ.setdefault("EMAIL_ENABLED", "false")
+
+from app import auth, models  # noqa: E402
+from app.api import app  # noqa: E402
+from app.database import Base, SessionLocal, engine, get_db  # noqa: E402
+
+
+def _run_migrations() -> None:
+    backend_root = Path(__file__).resolve().parents[1]
+    alembic_ini = backend_root / "alembic.ini"
+    config = Config(str(alembic_ini))
+    config.set_main_option("script_location", str(backend_root / "alembic"))
+    command.upgrade(config, "head")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _ensure_schema():
+    _run_migrations()
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def db_session():
+    db = SessionLocal()
+    try:
+        tables = [t.name for t in Base.metadata.sorted_tables]
+        if tables:
+            db.execute(text(f"TRUNCATE TABLE {', '.join(tables)} RESTART IDENTITY CASCADE"))
+            db.commit()
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def helpers(client, db_session):
+    def register_student(email: str) -> str:
+        resp = client.post(
+            "/register",
+            json={"email": email, "password": "password123", "confirm_password": "password123"},
+        )
+        assert resp.status_code == 200
+        return resp.json()["access_token"]
+
+    def login(email: str, password: str) -> str:
+        resp = client.post("/login", json={"email": email, "password": password})
+        assert resp.status_code == 200
+        return resp.json()["access_token"]
+
+    def make_organizer(email: str = "org@test.ro", password: str = "organizer123") -> None:
+        organizer = models.User(
+            email=email,
+            password_hash=auth.get_password_hash(password),
+            role=models.UserRole.organizator,
+        )
+        db_session.add(organizer)
+        db_session.commit()
+
+    def auth_header(token: str) -> dict:
+        return {"Authorization": f"Bearer {token}"}
+
+    return {
+        "client": client,
+        "db": db_session,
+        "register_student": register_student,
+        "login": login,
+        "make_organizer": make_organizer,
+        "auth_header": auth_header,
+    }
+

--- a/backend/integration_tests/test_postgres_smoke.py
+++ b/backend/integration_tests/test_postgres_smoke.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timedelta, timezone
+
+
+def test_postgres_end_to_end_flow(helpers):
+    client = helpers["client"]
+
+    helpers["make_organizer"]()
+    organizer_token = helpers["login"]("org@test.ro", "organizer123")
+
+    event_payload = {
+        "title": "Integration Event",
+        "description": "Desc",
+        "category": "Tech",
+        "start_time": (datetime.now(timezone.utc) + timedelta(days=2)).isoformat(),
+        "city": "București",
+        "location": "Loc",
+        "max_seats": 10,
+        "tags": ["Tech"],
+        "status": "published",
+    }
+    created = client.post(
+        "/api/events",
+        json=event_payload,
+        headers=helpers["auth_header"](organizer_token),
+    )
+    assert created.status_code == 201
+    event_id = created.json()["id"]
+
+    student_token = helpers["register_student"]("student@test.ro")
+    registered = client.post(f"/api/events/{event_id}/register", headers=helpers["auth_header"](student_token))
+    assert registered.status_code == 201
+
+    participants = client.get(
+        f"/api/organizer/events/{event_id}/participants",
+        headers=helpers["auth_header"](organizer_token),
+    )
+    assert participants.status_code == 200
+    assert participants.json()["total"] == 1
+

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+coverage
 *.local
 
 # Editor directories and files

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -41,6 +41,7 @@
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "@vitest/coverage-v8": "^4.0.16",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
@@ -412,6 +413,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -4013,6 +4024,38 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.16.tgz",
+      "integrity": "sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.16",
+        "ast-v8-to-istanbul": "^0.3.8",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.16",
+        "vitest": "4.0.16"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.16",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
@@ -4239,6 +4282,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.9.tgz",
+      "integrity": "sha512-dSC6tJeOJxbZrPzPbv5mMd6CMiQ1ugaVXXPRad2fXUSsy1kstFn9XQWemV9VW7Y7kpxgQ/4WMoZfwdH8XSU48w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -5336,6 +5398,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5460,6 +5529,60 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -5910,6 +6033,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
+      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,8 +12,9 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test:unit": "vitest run",
+    "test:unit:coverage": "vitest run --coverage",
     "test:unit:watch": "vitest",
-    "test": "npm run lint && npm run test:unit && npm run build",
+    "test": "npm run lint && npm run test:unit:coverage && npm run build",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -50,6 +51,7 @@
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "@vitest/coverage-v8": "^4.0.16",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -18,5 +18,18 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./tests/setup.ts'],
     css: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'lcov'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.d.ts', 'src/types/**', 'tests/**', '**/*.test.*', '**/*.spec.*'],
+      thresholds: {
+        lines: 5,
+        functions: 5,
+        branches: 2,
+        statements: 5,
+      },
+    },
   },
 })


### PR DESCRIPTION
**Summary**
- Adds backend + frontend coverage reporting with minimum thresholds enforced in CI, and introduces Postgres-backed integration tests running in CI.

**Changes**
- CI: enforce backend coverage via `pytest --cov-fail-under=70` and upload `backend/coverage.xml` artifact.
- UI: enable Vitest coverage (v8) with low initial thresholds, generate `ui/coverage` reports, and upload as CI artifact.
- Backend: add Postgres integration test suite under `backend/integration_tests` (runs only when `RUN_INTEGRATION_TESTS=1`).
- CI: add `backend-integration` job with a Postgres service to execute the integration suite.

**Testing**
- `cd backend && pytest --cov-report=xml:coverage.xml --cov-fail-under=70`
- `cd ui && npm test`

**Risk & Impact**
- CI will now fail if backend coverage drops below 70% or if UI coverage drops below the configured minimums.
- Integration tests require a Postgres service; locally they are skipped unless `RUN_INTEGRATION_TESTS=1` is set.

**Related TODO items**
- [x] Coverage reporting for backend/frontend with minimum thresholds in CI.
- [x] Integration tests hitting a real test database (not just unit tests).