### PR TITLE
feat: near-real-time ML refresh and richer signals

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -59,6 +59,7 @@
 - [x] Recommendations ML: schedule periodic retraining (cron/CronJob) and monitor quality metrics (CTR, register conversion).
 - [x] Personalization: use ML ranking as a unified "For You" sort across event lists/search/filters (not only `/api/recommendations`).
 - [x] Analytics: add interaction tracking (impressions/clicks/dwell/search/filter/share) and feed signals into ML training.
+- [x] Personalization: near-real-time refresh of `user_recommendations` on meaningful interactions (config-gated).
 - [x] Experiments: add A/B assignment + feature flags for personalization rollouts (control vs ML ranking).
 - [x] Personalization: "Why am I seeing this?" explanations + user controls (hide tags/organizers, show less like this, personalization settings).
 - [x] Notifications: personalized digests + "filling fast" alerts with opt-in/out preferences.

--- a/backend/alembic/versions/0018_recommender_models.py
+++ b/backend/alembic/versions/0018_recommender_models.py
@@ -1,0 +1,40 @@
+"""Persist trained recommender model weights
+
+Revision ID: 0018_recommender_models
+Revises: 0017_event_moderation
+Create Date: 2025-12-18
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0018_recommender_models"
+down_revision = "0017_event_moderation"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "recommender_models",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("model_version", sa.String(length=100), nullable=False),
+        sa.Column("feature_names", sa.JSON(), nullable=False),
+        sa.Column("weights", sa.JSON(), nullable=False),
+        sa.Column("meta", sa.JSON(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("model_version", name="uq_recommender_models_model_version"),
+    )
+
+    op.create_index("ix_recommender_models_model_version", "recommender_models", ["model_version"], unique=False)
+    op.create_index("ix_recommender_models_is_active", "recommender_models", ["is_active"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_recommender_models_is_active", table_name="recommender_models")
+    op.drop_index("ix_recommender_models_model_version", table_name="recommender_models")
+    op.drop_table("recommender_models")
+

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -44,6 +44,9 @@ class Settings(BaseSettings):
 
     recommendations_use_ml_cache: bool = True
     recommendations_cache_max_age_seconds: int = 60 * 60 * 24
+    recommendations_realtime_refresh_enabled: bool = False
+    recommendations_realtime_refresh_min_interval_seconds: int = 300
+    recommendations_realtime_refresh_top_n: int = 50
 
     analytics_enabled: bool = True
     analytics_rate_limit: int = 120

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -209,6 +209,19 @@ class UserRecommendation(Base):
     event = relationship("Event", foreign_keys=[event_id])
 
 
+class RecommenderModel(Base):
+    __tablename__ = "recommender_models"
+    __table_args__ = (UniqueConstraint("model_version", name="uq_recommender_models_model_version"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    model_version = Column(String(100), nullable=False, index=True)
+    feature_names = Column(JSON, nullable=False)
+    weights = Column(JSON, nullable=False)
+    meta = Column(JSON, nullable=True)
+    is_active = Column(Boolean, nullable=False, server_default="false")
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+
+
 class EventInteraction(Base):
     __tablename__ = "event_interactions"
 

--- a/backend/tests/test_recommendations_realtime_refresh.py
+++ b/backend/tests/test_recommendations_realtime_refresh.py
@@ -1,0 +1,149 @@
+from datetime import datetime, timedelta, timezone
+
+from app import api as api_module, auth, models
+
+
+def _set_setting(obj, name: str, value):  # noqa: ANN001
+    original = getattr(obj, name)
+    setattr(obj, name, value)
+    return original
+
+
+def test_interactions_enqueues_refresh_job_when_enabled_and_dedupes(helpers):
+    client = helpers["client"]
+    db = helpers["db"]
+
+    token = helpers["register_student"]("student-realtime@test.ro")
+    student = db.query(models.User).filter(models.User.email == "student-realtime@test.ro").first()
+    assert student is not None
+
+    organizer = models.User(
+        email="org-realtime@test.ro",
+        password_hash=auth.get_password_hash("organizer123"),
+        role=models.UserRole.organizator,
+    )
+    db.add(organizer)
+    db.commit()
+    db.refresh(organizer)
+
+    event = models.Event(
+        title="Realtime Event",
+        start_time=datetime.now(timezone.utc) + timedelta(days=1),
+        owner_id=int(organizer.id),
+        status="published",
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+
+    originals = {}
+    try:
+        originals["task_queue_enabled"] = _set_setting(api_module.settings, "task_queue_enabled", True)
+        originals["recommendations_realtime_refresh_enabled"] = _set_setting(
+            api_module.settings, "recommendations_realtime_refresh_enabled", True
+        )
+        originals["recommendations_realtime_refresh_min_interval_seconds"] = _set_setting(
+            api_module.settings, "recommendations_realtime_refresh_min_interval_seconds", 0
+        )
+
+        resp = client.post(
+            "/api/analytics/interactions",
+            json={"events": [{"interaction_type": "click", "event_id": int(event.id)}]},
+            headers=helpers["auth_header"](token),
+        )
+        assert resp.status_code == 204
+
+        jobs = (
+            db.query(models.BackgroundJob)
+            .filter(models.BackgroundJob.job_type == "refresh_user_recommendations_ml")
+            .all()
+        )
+        assert len(jobs) == 1
+        assert jobs[0].payload["user_id"] == int(student.id)
+        assert jobs[0].payload["skip_training"] is True
+
+        resp2 = client.post(
+            "/api/analytics/interactions",
+            json={"events": [{"interaction_type": "click", "event_id": int(event.id)}]},
+            headers=helpers["auth_header"](token),
+        )
+        assert resp2.status_code == 204
+
+        jobs2 = (
+            db.query(models.BackgroundJob)
+            .filter(models.BackgroundJob.job_type == "refresh_user_recommendations_ml")
+            .all()
+        )
+        assert len(jobs2) == 1
+    finally:
+        for name, value in originals.items():
+            setattr(api_module.settings, name, value)
+
+
+def test_interactions_respects_realtime_refresh_min_interval(helpers):
+    client = helpers["client"]
+    db = helpers["db"]
+
+    token = helpers["register_student"]("student-interval@test.ro")
+    student = db.query(models.User).filter(models.User.email == "student-interval@test.ro").first()
+    assert student is not None
+
+    organizer = models.User(
+        email="org-interval@test.ro",
+        password_hash=auth.get_password_hash("organizer123"),
+        role=models.UserRole.organizator,
+    )
+    db.add(organizer)
+    db.commit()
+    db.refresh(organizer)
+
+    event = models.Event(
+        title="Interval Event",
+        start_time=datetime.now(timezone.utc) + timedelta(days=1),
+        owner_id=int(organizer.id),
+        status="published",
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+
+    db.add(
+        models.UserRecommendation(
+            user_id=int(student.id),
+            event_id=int(event.id),
+            score=0.9,
+            rank=1,
+            model_version="test-model",
+            generated_at=datetime.now(timezone.utc),
+            reason="test",
+        )
+    )
+    db.commit()
+
+    originals = {}
+    try:
+        originals["task_queue_enabled"] = _set_setting(api_module.settings, "task_queue_enabled", True)
+        originals["recommendations_realtime_refresh_enabled"] = _set_setting(
+            api_module.settings, "recommendations_realtime_refresh_enabled", True
+        )
+        originals["recommendations_realtime_refresh_min_interval_seconds"] = _set_setting(
+            api_module.settings, "recommendations_realtime_refresh_min_interval_seconds", 3600
+        )
+
+        resp = client.post(
+            "/api/analytics/interactions",
+            json={"events": [{"interaction_type": "click", "event_id": int(event.id)}]},
+            headers=helpers["auth_header"](token),
+        )
+        assert resp.status_code == 204
+
+        jobs = (
+            db.query(models.BackgroundJob)
+            .filter(models.BackgroundJob.job_type == "refresh_user_recommendations_ml")
+            .all()
+        )
+        assert jobs == []
+    finally:
+        for name, value in originals.items():
+            setattr(api_module.settings, name, value)
+

--- a/docs/recommendations-ml.md
+++ b/docs/recommendations-ml.md
@@ -11,6 +11,7 @@ The trainer uses only data already stored in the DB:
 - User interest tags (`user_interest_tags`)
 - Event tags (`event_tags`)
 - Registrations (and `attended`) + favorites
+- Interaction tracking (`event_interactions`): impressions/clicks/views/dwell/share/search/filter/register/unregister
 - Event attributes: `category`, `city`, `owner_id`, `start_time`
 - Popularity proxy: number of registrations per event
 
@@ -20,6 +21,11 @@ Recommendations are stored in `user_recommendations`:
 
 - `user_id`, `event_id`, `score`, `rank`
 - `model_version`, `generated_at`, `reason`
+
+Trained model weights are stored in `recommender_models`:
+
+- `model_version`, `feature_names`, `weights`, `meta`
+- `is_active` marks which model to use for online refresh / scoring
 
 ## How to run training
 
@@ -40,12 +46,25 @@ Useful flags:
 
 The script prints a basic offline metric: `hitrate@10`.
 
+## Per-user refresh (near-real-time personalization)
+
+To refresh recommendations for a single user using the last persisted model weights:
+
+```bash
+export DATABASE_URL="postgresql://..."
+export SECRET_KEY="any-value"
+python backend/scripts/recompute_recommendations_ml.py --user-id 123 --skip-training
+```
+
+This updates `user_recommendations` only for that user.
+
 ## Scheduled retraining (cron/K8s)
 
 This repo includes a DB-backed task queue + worker (`docker-compose.yml` service `worker`), and a job type that can
 run the ML trainer:
 
 - `recompute_recommendations_ml`
+- `refresh_user_recommendations_ml` (used for near-real-time per-user refresh)
 
 To enqueue the retraining job (idempotent: won’t enqueue if one is queued/running):
 
@@ -70,6 +89,13 @@ In Kubernetes, run the same command from a CronJob using the `backend` image.
 - uses cached rows when `recommendations_use_ml_cache=true` and the cache age is within
   `recommendations_cache_max_age_seconds`
 - falls back to the existing tag/popularity heuristic otherwise
+
+When enabled, `POST /api/analytics/interactions` can enqueue `refresh_user_recommendations_ml` jobs to keep a student's
+cache fresh after meaningful interactions (click/view/share/register/search/filter). This is gated by:
+
+- `task_queue_enabled=true` (worker running)
+- `recommendations_realtime_refresh_enabled=true`
+- `recommendations_realtime_refresh_min_interval_seconds` (throttle)
 
 ## Monitoring
 


### PR DESCRIPTION
- **Summary**
  - Adds persisted ML model weights plus a config-gated near-real-time per-user refresh so recommendations react quickly to new interactions, and expands the trainer to learn from more tracked signals.
- **Changes**
  - Backend: add `recommender_models` table (migration `0018`) to persist trained model weights/metadata and mark an active model.
  - Backend: extend `backend/scripts/recompute_recommendations_ml.py` with `--skip-training` + `--user-id`, incorporate impressions/share/search/filter/unregister signals, and fix scoring exclusion to only skip registered events.
  - Backend: add `refresh_user_recommendations_ml` job type + enqueue logic from `/api/analytics/interactions` with dedupe + min-interval throttling.
  - Tests/docs: add realtime refresh enqueue tests and update `docs/recommendations-ml.md`.
- **Testing**
  - `python3 backend/scripts/generate_openapi.py`
  - `cd backend && pytest`
- **Risk & Impact**
  - Adds DB migration `0018` (new table `recommender_models`).
  - Near-real-time refresh is off by default; enable via `recommendations_realtime_refresh_enabled=true` and `task_queue_enabled=true`.
- **Related TODO items**
  - [x] Analytics: add interaction tracking (impressions/clicks/dwell/search/filter/share) and feed signals into ML training.
  - [x] Personalization: near-real-time refresh of `user_recommendations` on meaningful interactions (config-gated).
