### PR TITLE
chore: seed admin test account

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -108,7 +108,7 @@
 - [x] E2E (Playwright): student profile flows (interest tags + academic profile fields).
 - [x] E2E (Playwright): organizer participants tools (attendance toggle, CSV export, email participants).
 - [ ] E2E (Playwright): organizer clone event + soft-delete/restore flows.
-- [ ] E2E (Playwright): admin dashboard flows (user management + event moderation) once admin seed exists.
+- [ ] E2E (Playwright): admin dashboard flows (user management + event moderation).
 - [ ] E2E (Playwright): personalization controls (hide tags/blocked organizers) + “Why am I seeing this?” drawer.
 - [ ] E2E (Playwright): notifications preferences + admin-triggered digest/filling-fast job enqueue.
 - [x] Stress/load tests for critical endpoints (event list, registration, recommendations).

--- a/backend/seed_data.py
+++ b/backend/seed_data.py
@@ -332,6 +332,10 @@ ORGANIZERS = [
     }
 ]
 
+ADMINS = [
+    {"email": "admin@test.com", "full_name": "EventLink Admin", "password": "test123"},
+]
+
 
 def seed_database():
     """Seed the database with sample data."""
@@ -417,6 +421,21 @@ def seed_database():
             organizer_objects.append(organizer)
         session.flush()
         print(f"   Created {len(ORGANIZERS)} organizers")
+
+        # Create admins
+        print("🛡️ Creating admins...")
+        admin_objects = []
+        for admin_data in ADMINS:
+            admin = User(
+                email=admin_data["email"],
+                password_hash=pwd_context.hash(admin_data["password"]),
+                role=UserRole.admin,
+                full_name=admin_data["full_name"],
+            )
+            session.add(admin)
+            admin_objects.append(admin)
+        session.flush()
+        print(f"   Created {len(ADMINS)} admins")
         
         # Create events
         print("📅 Creating events...")
@@ -520,6 +539,9 @@ def seed_database():
         print("   Organizers:")
         for o in ORGANIZERS:
             print(f"      - {o['email']} / {o['password']}")
+        print("   Admins:")
+        for a in ADMINS:
+            print(f"      - {a['email']} / {a['password']}")
         
     except Exception as e:
         session.rollback()


### PR DESCRIPTION
**Summary**
- Adds a seeded admin test account so CI/local seed data includes a stable admin login for upcoming admin-dashboard E2E coverage.

**Changes**
- Seed `admin@test.com` / `test123` with role `admin` in `backend/seed_data.py`.
- Update `TODO.md` to remove the “once admin seed exists” qualifier from the admin E2E task.

**Testing**
- `python3 -m py_compile backend/seed_data.py`

**Risk & Impact**
- Low risk: affects dev/CI seeding only; introduces a known admin user in seeded data.

**Related TODO items**
- [ ] E2E (Playwright): admin dashboard flows (user management + event moderation).