### PR TITLE
config(codacy): scope Lizard exclude_paths to framework/tests (phase 6)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,4 +1,8 @@
 ---
+# Codacy project configuration.
+# The ``exclude_paths`` below are scoped to engines where the defaults produce
+# noise that doesn't reflect real code-quality problems: tests (bandit),
+# generated lock files (lizard), and framework-templated Alembic migrations.
 engines:
   bandit:
     exclude_paths:
@@ -6,3 +10,18 @@ engines:
       - backend/integration_tests/**
   pylint:
     python_version: 3
+  lizard:
+    exclude_paths:
+      # Alembic migrations use long upgrade()/downgrade() methods by design —
+      # breaking them up would split a single DDL transaction.
+      - backend/alembic/versions/**
+      # Generated files where line counts reflect dependency data, not code.
+      - ui/package-lock.json
+      - ui/package.json
+      - "**/*.lock"
+      # Test fixtures intentionally seed many rows; splitting them hurts
+      # readability without reducing risk.
+      - backend/tests/**
+      - backend/integration_tests/**
+      - ui/tests/**
+


### PR DESCRIPTION
## **User description**
Exclude alembic/versions, ui/package-lock.json, and test trees from Lizard NLOC counting. Matches existing bandit tests exclusion. Should clear ~25 more Codacy hits on main without hiding real issues.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Scoped Codacy `lizard` exclusions to generated Alembic migrations, lockfiles, and test trees to avoid counting non-production code in NLOC. Aligns with existing `bandit` test exclusions and removes ~25 noisy findings on `main` while keeping real issues visible.

- **Bug Fixes**
  - Set `lizard.exclude_paths` for `backend/alembic/versions/**`, `ui/package-lock.json`, `ui/package.json`, and `**/*.lock`.
  - Excluded tests to match `bandit`: `backend/tests/**`, `backend/integration_tests/**`, `ui/tests/**`; added rationale comments in `.codacy.yml`.

<sup>Written for commit 795d6efe2670e5067bcfbbf5a23352947aa8bc78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Reduce noisy Codacy warnings from generated files and tests**

### What Changed
- Codacy no longer flags long-method warnings in generated Alembic migrations, lock files, and test files
- Test folders are excluded for the same scan type already used for other quality checks, so reports stay focused on production code
- Added notes explaining why these paths are excluded

### Impact
`✅ Fewer false-positive code quality alerts`
`✅ Cleaner Codacy reports for production code`
`✅ Less noise from generated files and test fixtures`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=bIWs8d3SC_1CLccyrc-xGltAfNBCONdduoKAGVteSC0&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
