### PR TITLE
fix(sonar): mark EventsActiveFiltersProps as Readonly (S6759)

### DIFF
--- a/ui/src/pages/events/EventsActiveFilters.tsx
+++ b/ui/src/pages/events/EventsActiveFilters.tsx
@@ -15,22 +15,22 @@ import type { EventsPageFilters } from './useEventsPageFilters';
 
 type FilterKey = 'search' | 'category' | 'start_date' | 'city' | 'location';
 
-export type EventsActiveFiltersProps = {
+export type EventsActiveFiltersProps = Readonly<{
   filters: EventsPageFilters;
   hasActiveFilters: boolean;
   language: ResolvedLanguage;
   dateFnsLocale: Locale;
-  labels: {
+  labels: Readonly<{
     activeFilters: string;
     filterSearch: string;
     filterFrom: string;
     filterCity: string;
     filterLocation: string;
     clearAll: string;
-  };
+  }>;
   onUpdateFilter: (patch: Partial<EventsPageFilters>) => void;
   onClearAll: () => void;
-};
+}>;
 
 /** Render the pill-list summary of every filter currently applied. */
 export function EventsActiveFilters({


### PR DESCRIPTION
## **User description**
Clear the last SonarCloud issue on main — typescript:S6759 on the new EventsActiveFilters component (missing Readonly wrapper on its props type). No runtime change; matches the existing AcademicProfileCardProps pattern.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Marked `EventsActiveFiltersProps` as `Readonly`, including nested `labels`, to enforce immutable props and clear SonarCloud rule typescript:S6759. Aligns with `AcademicProfileCardProps`; no runtime change.

<sup>Written for commit d2d171548370d4d039a29680ac3e4a026a5734a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Make event filter props read-only

### What Changed
- Event filters now treat their incoming props and label text as read-only
- This removes the SonarCloud warning for mutable props without changing how filters work

### Impact
`✅ Fewer SonarCloud warnings`
`✅ Cleaner CI checks`
`✅ No change in filter behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=q4HWtnQyvDhEbPMM-24fvz1VhSNU-j-reOuiDN3-2YY&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
