### PR TITLE
fix(ds): revert PTC-W0034 getattr workarounds + JSDoc on renderChip

### DIFF
--- a/backend/tests/test_api_branch_closure_extra.py
+++ b/backend/tests/test_api_branch_closure_extra.py
@@ -106,10 +106,11 @@ def test_serializers_cache_fresh_and_create_event_optional_start_time(monkeypatc
     _assert_serializer_defaults(event)
 
     now = datetime.now(timezone.utc)
-    cache_is_fresh = getattr(api, "_recommendations_cache_is_fresh")
-    assert cache_is_fresh(db=ScalarDb(now), user_id=1, now=now) is True
+    assert api._recommendations_cache_is_fresh(db=ScalarDb(now), user_id=1, now=now) is True
     assert (
-        cache_is_fresh(db=ScalarDb(now.replace(tzinfo=None)), user_id=1, now=now)
+        api._recommendations_cache_is_fresh(
+            db=ScalarDb(now.replace(tzinfo=None)), user_id=1, now=now,
+        )
         is True
     )
     _assert_create_event_accepts_missing_start_time(monkeypatch)
@@ -581,12 +582,10 @@ def test_recommendation_reason_map_empty_and_invalid_dwell_seconds_do_not_query_
             """Implements the query helper."""
             raise AssertionError("query should not run")
 
-    recommendation_reason_map = getattr(api, "_recommendation_reason_map")
-    event_learning_delta = getattr(api, "_event_learning_delta")
     assert (
-        recommendation_reason_map(db=_NoQueryDb(), user_id=1, event_ids=[]) == {}
+        api._recommendation_reason_map(db=_NoQueryDb(), user_id=1, event_ids=[]) == {}
     )
-    assert event_learning_delta(
+    assert api._event_learning_delta(
         interaction_type="dwell", meta={"seconds": "slow"}
     ) == pytest.approx(0.0)
     with pytest.raises(AssertionError, match="query should not run"):

--- a/backend/tests/test_api_branch_interactions.py
+++ b/backend/tests/test_api_branch_interactions.py
@@ -454,12 +454,10 @@ def test_recommendation_reason_map_empty_and_invalid_dwell_seconds_do_not_query_
             """Implements the query helper."""
             raise AssertionError("query should not run")
 
-    recommendation_reason_map = getattr(api, "_recommendation_reason_map")
-    event_learning_delta = getattr(api, "_event_learning_delta")
     assert (
-        recommendation_reason_map(db=_NoQueryDb(), user_id=1, event_ids=[]) == {}
+        api._recommendation_reason_map(db=_NoQueryDb(), user_id=1, event_ids=[]) == {}
     )
-    assert event_learning_delta(
+    assert api._event_learning_delta(
         interaction_type="dwell", meta={"seconds": "slow"}
     ) == pytest.approx(0.0)
     with pytest.raises(AssertionError, match="query should not run"):

--- a/backend/tests/test_api_coverage_closure.py
+++ b/backend/tests/test_api_coverage_closure.py
@@ -43,13 +43,9 @@ def test_helper_math_and_admin_branches(monkeypatch, helpers):
     assert "many_links" in flags
     assert status in {"clean", "flagged"}
 
-    format_ics_dt = getattr(api, "_format_ics_dt")
-    in_experiment_treatment = getattr(api, "_in_experiment_treatment")
-    is_admin = getattr(api, "_is_admin")
-    jaccard_similarity = getattr(api, "_jaccard_similarity")
-    jaccard_empty = jaccard_similarity(set(), set())
-    jaccard_one_side = jaccard_similarity({"a"}, set())
-    ics_null = format_ics_dt(None)
+    jaccard_empty = api._jaccard_similarity(set(), set())
+    jaccard_one_side = api._jaccard_similarity({"a"}, set())
+    ics_null = api._format_ics_dt(None)
     assert jaccard_empty == pytest.approx(1.0)
     assert jaccard_one_side == pytest.approx(0.0)
     assert ics_null == ""
@@ -69,8 +65,8 @@ def test_helper_math_and_admin_branches(monkeypatch, helpers):
 
     bucket = api._experiment_bucket("exp", "identity")
     assert 0 <= bucket < 100
-    in_treatment = in_experiment_treatment("exp", 50, "identity")
-    none_is_admin = is_admin(None)
+    in_treatment = api._in_experiment_treatment("exp", 50, "identity")
+    none_is_admin = api._is_admin(None)
     assert in_treatment is (bucket < 50)
 
     assert none_is_admin is False
@@ -80,7 +76,7 @@ def test_helper_math_and_admin_branches(monkeypatch, helpers):
         role=models.UserRole.student,
     )
     set_settings(monkeypatch, admin_emails=["admin@test.ro"])
-    user_is_admin = is_admin(user)
+    user_is_admin = api._is_admin(user)
     assert user_is_admin is True
 
 
@@ -261,7 +257,7 @@ def test_cached_recommendations_handle_disabled_cache_and_empty_user(
     now = datetime.now(timezone.utc)
     set_settings(monkeypatch, recommendations_use_ml_cache=False)
     assert (
-        getattr(api, "_load_cached_recommendations")(
+        api._load_cached_recommendations(
             db=ctx.db, user=ctx.student, now=now, registered_event_ids=[], lang="en"
         )
         is None

--- a/backend/tests/test_api_helper_coverage.py
+++ b/backend/tests/test_api_helper_coverage.py
@@ -249,9 +249,8 @@ def test_refresh_token_branches():
 
 def test_experiment_treatment_boundary_values():
     """Experiment bucketing should honor zero and full rollout boundaries."""
-    in_experiment_treatment = getattr(api, "_in_experiment_treatment")
-    never_bucket = in_experiment_treatment("exp", 0, "1")
-    always_bucket = in_experiment_treatment("exp", 100, "1")
+    never_bucket = api._in_experiment_treatment("exp", 0, "1")
+    always_bucket = api._in_experiment_treatment("exp", 100, "1")
     assert never_bucket is False
     assert always_bucket is True
 

--- a/backend/tests/test_codacy_tool_sync.py
+++ b/backend/tests/test_codacy_tool_sync.py
@@ -25,16 +25,11 @@ def _load_module():
         sys.path.pop(0)
 
 
-def _planned_tool_payload(module, *args, **kwargs):
-    """Invokes the ``_planned_tool_payload`` helper on ``module`` via ``getattr``."""
-    return getattr(module, "_planned_tool_payload")(*args, **kwargs)
-
-
 def test_planned_tool_payload_disables_legacy_tools():
     """Verifies planned tool payload disables legacy tools behavior."""
     module = _load_module()
 
-    payload, notes = _planned_tool_payload(module, "ESLint", {"isEnabled": True})
+    payload, notes = module._planned_tool_payload("ESLint", {"isEnabled": True})
 
     assert payload == {"enabled": False}
     assert notes == [
@@ -46,7 +41,7 @@ def test_planned_tool_payload_disables_lizard_for_test_noise_control():
     """Verifies planned tool payload disables lizard for test noise control behavior."""
     module = _load_module()
 
-    payload, notes = _planned_tool_payload(module, "Lizard", {"isEnabled": True})
+    payload, notes = module._planned_tool_payload("Lizard", {"isEnabled": True})
 
     assert payload == {"enabled": False}
     assert notes == []
@@ -56,9 +51,7 @@ def test_planned_tool_payload_enables_configuration_file_when_available():
     """Verifies planned tool payload enables configuration file when available behavior."""
     module = _load_module()
 
-    payload, notes = _planned_tool_payload(
-        module,
-        "ESLint9",
+    payload, notes = module._planned_tool_payload("ESLint9",
         {
             "isEnabled": True,
             "hasConfigurationFile": True,
@@ -78,9 +71,7 @@ def test_planned_tool_payload_enables_legacy_config_when_legacy_tool_is_present(
     """
     module = _load_module()
 
-    payload, notes = _planned_tool_payload(
-        module,
-        "ESLint",
+    payload, notes = module._planned_tool_payload("ESLint",
         {
             "isEnabled": True,
             "hasConfigurationFile": True,
@@ -96,9 +87,7 @@ def test_planned_tool_payload_skips_missing_configuration_files():
     """Verifies planned tool payload skips missing configuration files behavior."""
     module = _load_module()
 
-    payload, notes = _planned_tool_payload(
-        module,
-        "Stylelint",
+    payload, notes = module._planned_tool_payload("Stylelint",
         {
             "isEnabled": True,
             "hasConfigurationFile": False,
@@ -120,9 +109,7 @@ def test_planned_tool_payload_enables_prospector_configuration_file_when_availab
     """
     module = _load_module()
 
-    payload, notes = _planned_tool_payload(
-        module,
-        "Prospector",
+    payload, notes = module._planned_tool_payload("Prospector",
         {
             "isEnabled": True,
             "hasConfigurationFile": True,
@@ -167,7 +154,7 @@ def test_append_markdown_section_uses_none_marker_for_empty_values():
     module = _load_module()
     lines = ["# Title"]
 
-    getattr(module, "_append_markdown_section")(lines, "Tool Changes", [])
+    module._append_markdown_section(lines, "Tool Changes", [])
 
     assert lines == ["# Title", "", "## Tool Changes", module.NONE_MARKDOWN_ITEM]
 

--- a/backend/tests/test_codacy_zero.py
+++ b/backend/tests/test_codacy_zero.py
@@ -69,10 +69,8 @@ def test_load_module_raises_when_import_spec_is_missing(
 def test_quality_new_issues_prefers_quality_section() -> None:
     """Verifies quality new issues prefers quality section behavior."""
     module = _load_module()
-    quality_new_issues = getattr(module, "_quality_new_issues")
-
     assert (
-        quality_new_issues(
+        module._quality_new_issues(
             {
                 "newIssues": 99,
                 "quality": {"newIssues": 4},
@@ -197,8 +195,7 @@ def test_wait_for_branch_analysis_uses_latest_branch_head(
     )
     monkeypatch.setattr(module.time, "sleep", sleeps.append)
 
-    wait_for_branch_analysis = getattr(module, "_wait_for_branch_analysis")
-    status, open_issues, findings = wait_for_branch_analysis(
+    status, open_issues, findings = module._wait_for_branch_analysis(
         _request(module, branch="main", commit_sha=_HEAD_SHA, poll_seconds=6)
     )
 

--- a/backend/tests/test_quality_script_security.py
+++ b/backend/tests/test_quality_script_security.py
@@ -137,8 +137,7 @@ def test_api_get_retries_retryable_http_statuses(
     )
     monkeypatch.setattr(check_required_checks.time, "sleep", sleeps.append)
 
-    api_get = getattr(check_required_checks, "_api_get")
-    payload = api_get(
+    payload = check_required_checks._api_get(
         "https://api.github.com/repos/Prekzursil/event-link/commits/abcdef/check-runs",
         "token",
     )

--- a/backend/tests/test_recompute_recommendations_ml.py
+++ b/backend/tests/test_recompute_recommendations_ml.py
@@ -61,12 +61,11 @@ def test_helper_feature_vector_reason_and_impression_weights() -> None:
     assert vector[3] == pytest.approx(1.0)
     assert vector[4] == pytest.approx(1.0)
     assert vector[5] == pytest.approx(1.0)
-    reason_for = getattr(module, "_reason_for")
     assert (
-        reason_for(user=user, event=event, lang="en")
+        module._reason_for(user=user, event=event, lang="en")
         == "Your interests: python"
     )
-    assert reason_for(user=user, event=other_event, lang="ro") == "În apropiere"
+    assert module._reason_for(user=user, event=other_event, lang="ro") == "În apropiere"
     assert module._impression_negative_weight(None) == pytest.approx(0.05)
     assert module._impression_negative_weight(1) == pytest.approx(0.25)
     assert module._impression_negative_weight(4) == pytest.approx(0.15)
@@ -397,7 +396,7 @@ def test_reason_for_city_and_generic_fallback_edges() -> None:
     )
     reason_for = getattr(module, "_reason_for")
     assert (
-        reason_for(user=same_city_user, event=same_city_event, lang="en")
+        module._reason_for(user=same_city_user, event=same_city_event, lang="en")
         == "Near you"
     )
     assert (
@@ -405,7 +404,7 @@ def test_reason_for_city_and_generic_fallback_edges() -> None:
         == "Near you"
     )
     assert (
-        reason_for(user=generic_user, event=generic_event, lang="ro")
+        module._reason_for(user=generic_user, event=generic_event, lang="ro")
         == "Recomandat pentru tine"
     )
 

--- a/ui/src/pages/events/EventsActiveFilters.tsx
+++ b/ui/src/pages/events/EventsActiveFilters.tsx
@@ -54,6 +54,7 @@ export function EventsActiveFilters({
     location: { location: '' },
   };
 
+  /** Renders one filter chip with its label and a close affordance. */
   function renderChip(key: FilterKey, label: ReactNode) {
     return (
       <Badge key={key} variant="secondary" className="gap-1">


### PR DESCRIPTION
## **User description**
DS dashboard reported 36 visible issues on main; 22 of them were the getattr-based workarounds I added to quiet Pylint W0212. Now that `.pylintrc` disables protected-access, revert to direct `obj._priv` calls. Also add a JSDoc comment to the inner renderChip helper. Should knock out 22 PTC-W0034 + 1 JS-D1001.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Reverted getattr-based calls to direct private helper access across tests now that protected-access is disabled, resolving DeepSource PTC-W0034 warnings. Also added a JSDoc comment to the inner `renderChip` in `EventsActiveFilters.tsx` to clear JS-D1001.

- **Refactors**
  - Replaced `getattr(module, "_foo")(…)` with `module._foo(…)` in test modules; removed the `_planned_tool_payload` shim in `test_codacy_tool_sync.py`.

<sup>Written for commit ce6f28dad2cf051eb4e8469fcccd0d555f7f0672. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Remove test workarounds and add a missing helper comment

### What Changed
- Replaced indirect private-helper calls in tests with direct calls now that protected-access warnings are disabled
- Removed an extra test-only wrapper in the Codacy sync coverage and called the planned tool payload helper directly
- Added a short comment for the event filter chip renderer

### Impact
`✅ Fewer code-quality warnings in tests`
`✅ Simpler test maintenance`
`✅ Clearer event filter helper docs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=CbDKnCSyzFtb1ezENr-f7BUvuYmpKMlaEk3HUXl1Svk&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
