### PR TITLE
fix(ds): revert remaining 5 PTC-W0034 getattr calls

### DIFF
--- a/backend/tests/test_api_coverage_closure.py
+++ b/backend/tests/test_api_coverage_closure.py
@@ -277,7 +277,7 @@ def test_cached_recommendations_handle_disabled_cache_and_empty_user(
     ctx.db.add(fresh_user)
     ctx.db.commit()
     assert (
-        getattr(api, "_load_cached_recommendations")(
+        api._load_cached_recommendations(
             db=ctx.db, user=fresh_user, now=now, registered_event_ids=[], lang="en"
         )
         is None
@@ -296,7 +296,7 @@ def test_cached_recommendations_skip_registered_and_full_events(monkeypatch, hel
 
     monkeypatch.setattr(api, "_recommendations_cache_is_fresh", _always_fresh)
     assert (
-        getattr(api, "_load_cached_recommendations")(
+        api._load_cached_recommendations(
             db=ctx.db,
             user=ctx.student,
             now=now,
@@ -332,7 +332,7 @@ def test_cached_recommendations_skip_registered_and_full_events(monkeypatch, hel
         _unmatched_events_with_counts_query,
     )
     assert (
-        getattr(api, "_load_cached_recommendations")(
+        api._load_cached_recommendations(
             db=ctx.db, user=ctx.student, now=now, registered_event_ids=[], lang="en"
         )
         is None
@@ -343,7 +343,7 @@ def test_cached_recommendations_skip_registered_and_full_events(monkeypatch, hel
         _full_events_with_counts_query,
     )
     assert (
-        getattr(api, "_load_cached_recommendations")(
+        api._load_cached_recommendations(
             db=ctx.db, user=ctx.student, now=now, registered_event_ids=[], lang="en"
         )
         is None

--- a/backend/tests/test_recompute_recommendations_ml.py
+++ b/backend/tests/test_recompute_recommendations_ml.py
@@ -394,13 +394,12 @@ def test_reason_for_city_and_generic_fallback_edges() -> None:
     generic_event = _basic_event_features(
         module, now, city="timisoara", owner_id=3, days=4
     )
-    reason_for = getattr(module, "_reason_for")
     assert (
         module._reason_for(user=same_city_user, event=same_city_event, lang="en")
         == "Near you"
     )
     assert (
-        reason_for(user=weighted_city_user, event=weighted_city_event, lang="en")
+        module._reason_for(user=weighted_city_user, event=weighted_city_event, lang="en")
         == "Near you"
     )
     assert (


### PR DESCRIPTION
## **User description**
After PR #123 cleared 17 of 22 PTC-W0034 hits, DS dashboard still shows 5 (all in test_api_coverage_closure.py + one dead reason_for assignment in test_recompute_recommendations_ml.py). Revert to direct _priv access now that .pylintrc disables protected-access repo-wide.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replaced the last 5 `getattr` workarounds in tests with direct `_` attribute access to match `.pylintrc` (protected-access disabled) and clear remaining PTC-W0034 warnings.

- **Refactors**
  - `backend/tests/test_api_coverage_closure.py`: call `api._load_cached_recommendations(...)` directly in 4 places.
  - `backend/tests/test_recompute_recommendations_ml.py`: remove unused `reason_for = getattr(...)`; call `module._reason_for(...)` in assertion.

<sup>Written for commit c59bbf2dca703c0c712c2d0be7af74184ced29a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Keep recommendation tests using direct helper calls

### What Changed
- Recommendation coverage now calls the cached-recommendation helper directly instead of looking it up indirectly
- The fallback-reason test now uses the helper directly and removes one unused lookup variable
- Test behavior stays the same; only the test setup was simplified

### Impact
`✅ Fewer protected-access warnings`
`✅ Cleaner test coverage reports`
`✅ Simpler recommendation test maintenance`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=_qCG6hOAXenigpXJpoBRV6BherDVYoSpxY7RWVpvxAQ&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
