### PR TITLE
fix(test): await render on flaky admin-fallbacks tests

### DIFF
--- a/ui/tests/mega-pages-admin-fallbacks.test.tsx
+++ b/ui/tests/mega-pages-admin-fallbacks.test.tsx
@@ -31,12 +31,12 @@ describe('mega pages admin fallbacks', () => {
     await waitFor(() => expect(adminServiceMock.getStats).toHaveBeenCalled());
     await waitFor(() => expect(toastSpy).toHaveBeenCalled());
 
-    fireEvent.click(screen.getByRole('button', { name: /Reload/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Reload/i }));
     await waitFor(() => expect(adminServiceMock.getStats).toHaveBeenCalledTimes(2));
 
-    fireEvent.click(screen.getByRole('button', { name: /Retrain/i }));
-    fireEvent.click(screen.getByRole('button', { name: /Digest/i }));
-    fireEvent.click(screen.getByRole('button', { name: /Filling-fast/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Retrain/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Digest/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Filling-fast/i }));
     await waitFor(() => expect(toastSpy).toHaveBeenCalled());
 
     const usersTab = screen.getByRole('tab', { name: /Users/i });
@@ -198,8 +198,10 @@ describe('mega pages admin fallbacks', () => {
     fireEvent.mouseDown(usersTab);
     fireEvent.click(usersTab);
     await waitFor(() => expect(adminServiceMock.getUsers).toHaveBeenCalled());
-    expect(screen.getAllByText(/Organizer|Organizator/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText('-').length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Organizer|Organizator/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText('-').length).toBeGreaterThan(0);
+    });
 
     const organizerRow = screen.getByText(/student@test.local/i).closest('tr');
     fireEvent.click(


### PR DESCRIPTION
## **User description**
## Summary
Main CI went red after PR #127 merged (commit 42884c9): two tests in \`ui/tests/mega-pages-admin-fallbacks.test.tsx\` failed with \"Unable to find\" errors. The **same commit was green on the PR's CI**, so this is a flakiness race between the initial mount and the synchronous \`getByRole\` / \`getAllByText\` calls.

## Changes
- Switch four \`getByRole(...)\` calls to \`await findByRole(...)\` around the PersonalizationActions buttons (/Retrain/, /Digest/, /Filling-fast/) and the /Reload/ button.
- Wrap the second test's role-label + \"-\" assertions in \`waitFor(() => { ... })\` so the re-render settles before assertion.

Both patterns are already used elsewhere in the same file for similar async mounts.

## Test plan
- [ ] CI frontend job green on main after merge
- [ ] Other quality gates unaffected (no production code changed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky admin dashboard tests by awaiting renders before interactions and waiting for rows before assertions. Stabilizes CI; no production code changed.

- **Bug Fixes**
  - Switched four button lookups to `await screen.findByRole(...)` for Reload, Retrain, Digest, and Filling-fast.
  - Wrapped organizer role-label and "-" fallback checks in `waitFor(...)` so the second render settles before asserting.

<sup>Written for commit ce7e1fd9dd85d05e2e90e1a9cf8a234affa089d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Stabilize flaky admin dashboard fallback tests

### What Changed
- Waits for the admin dashboard buttons to appear before clicking Reload, Retrain, Digest, and Filling-fast
- Waits for the Users table fallback rows to settle before checking the Organizer label and missing-date dash
- Keeps the same coverage for error handling, callbacks, and pagination while reducing timing-related test failures

### Impact
`✅ Fewer false CI failures`
`✅ More reliable admin dashboard test runs`
`✅ Stable checks for fallback content`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=lt0BrxSgLv-arjtWEK_pKznk771Mlajza0nAcgARmwM&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
