### PR TITLE
fix(ci): bump QZP reusable workflows — Phase 2 per-flag Codecov + self-CI fix

### DIFF
--- a/.github/workflows/codecov-analytics.yml
+++ b/.github/workflows/codecov-analytics.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codecov-analytics.yml@d7a94db4ab57df42940832cf67b730c673af7da6
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codecov-analytics.yml@cc7e3095598478230cd85566a72e310acd1a8923
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-gate.yml
+++ b/.github/workflows/quality-zero-gate.yml
@@ -16,7 +16,7 @@ jobs:
   aggregate-gate:
     permissions:
       contents: read
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality-zero-gate.yml@d7a94db4ab57df42940832cf67b730c673af7da6
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality-zero-gate.yml@cc7e3095598478230cd85566a72e310acd1a8923
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-platform.yml
+++ b/.github/workflows/quality-zero-platform.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@d7a94db4ab57df42940832cf67b730c673af7da6
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@cc7e3095598478230cd85566a72e310acd1a8923
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}


### PR DESCRIPTION
## **User description**
Bumps three reusable-workflow pins to platform main (SHA `cc7e3095`) which includes:

- **QZP v2 Phase 2** (platform PR #89, merged 2026-04-23): `reusable-codecov-analytics.yml` loops once per `coverage.inputs[]` row and uploads each file under its own flag. Replaces the single `codecov-action` call that silently merged backend/ui/backend-integration into one unflagged blob. New `validate_codecov_flags.py` guard polls Codecov's v2 API and fails CI if any declared flag is missing from the stored report.
- **Platform self-CI fix** (platform PR #90, merged 2026-04-23): `reusable-scanner-matrix.yml` now stages coverage files at workspace root before the Codacy reporter action (the action doesn't accept `working-directory`), and the Codacy coverage upload is marked `continue-on-error` until `CODACY_PROJECT_TOKEN` is provisioned. `--policy-mode` is wired into the DeepSource Visible Zero lane (no-op for event-link — it stays on `zero` via the stack common template).

## Changes

- `.github/workflows/codecov-analytics.yml` → SHA `cc7e3095`
- `.github/workflows/quality-zero-platform.yml` → SHA `cc7e3095`
- `.github/workflows/quality-zero-gate.yml` → SHA `cc7e3095`

## Expected outcome

- [ ] Codecov dashboard shows three per-flag rows (`backend`, `ui`, `backend-integration`) at 100% each
- [ ] Aggregate coverage reflects the true per-flag state (not the prior merged ~58%)
- [ ] `validate_codecov_flags` either passes (all flags ingested) or warn-and-skips on 401 (read token scope)
- [ ] Event-link's own quality gates continue to enforce `zero` policy unchanged — this bump is platform-infra only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `Prekzursil/quality-zero-platform` reusable workflow pins to platform main to enable per-flag Codecov and align the quality gate with the latest platform behavior. Coverage for `backend`, `ui`, and `backend-integration` now uploads under separate flags and is validated.

- **New Features**
  - Per-flag Codecov uploads for `backend`, `ui`, and `backend-integration`.
  - `validate_codecov_flags.py` fails CI if any declared flag is missing (skips on 401).

- **Bug Fixes**
  - Stage coverage at workspace root for Codacy; mark upload `continue-on-error` until `CODACY_PROJECT_TOKEN` is set.
  - Wire `--policy-mode` into the DeepSource Visible Zero lane and bump the `quality-zero-gate` workflow for rollup consistency; gates remain on `zero`.

<sup>Written for commit e981c2209a442527683e86c10424896a56bdd3ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Update quality-check workflows to the latest platform version

### What Changed
- Bumped the shared Codecov workflow so coverage is reported per flag instead of being merged into one combined result
- Bumped the shared scanner workflow so coverage uploads and quality checks run with the platform’s latest fixes
- Bumped the shared quality gate workflow to keep the final quality check aligned with the updated platform behavior

### Impact
`✅ Accurate coverage by area`
`✅ Fewer CI failures from coverage uploads`
`✅ Stable quality gates with the latest platform fixes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=FMhRpCtfYMJJidWwY0XrB6pXOb7AmYSUY5zOrUBp-EM&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
