### PR TITLE
fix: postcss security + sonar coverage report paths

### DIFF
--- a/.github/workflows/codecov-analytics.yml
+++ b/.github/workflows/codecov-analytics.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codecov-analytics.yml@cc7e3095598478230cd85566a72e310acd1a8923
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codecov-analytics.yml@b24d2cabf9e2244fd4d981f40c91acdac3fd26eb
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/codecov-analytics.yml
+++ b/.github/workflows/codecov-analytics.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codecov-analytics.yml@6765a29004cf6a156dcb35205795f9c981dd27e8
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codecov-analytics.yml@bf487f26f816c2033bb848a0122d7f3ea8f804a4
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/codecov-analytics.yml
+++ b/.github/workflows/codecov-analytics.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codecov-analytics.yml@b24d2cabf9e2244fd4d981f40c91acdac3fd26eb
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codecov-analytics.yml@6765a29004cf6a156dcb35205795f9c981dd27e8
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codeql.yml@6765a29004cf6a156dcb35205795f9c981dd27e8
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codeql.yml@bf487f26f816c2033bb848a0122d7f3ea8f804a4
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codeql.yml@b24d2cabf9e2244fd4d981f40c91acdac3fd26eb
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codeql.yml@6765a29004cf6a156dcb35205795f9c981dd27e8
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codeql.yml@d7a94db4ab57df42940832cf67b730c673af7da6
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codeql.yml@b24d2cabf9e2244fd4d981f40c91acdac3fd26eb
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-backlog.yml
+++ b/.github/workflows/quality-zero-backlog.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-backlog-sweep.yml@b24d2cabf9e2244fd4d981f40c91acdac3fd26eb
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-backlog-sweep.yml@6765a29004cf6a156dcb35205795f9c981dd27e8
     with:
       repo_slug: ${{ github.repository }}
       lane: quality

--- a/.github/workflows/quality-zero-backlog.yml
+++ b/.github/workflows/quality-zero-backlog.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-backlog-sweep.yml@7268fee30f1cf796938d97fe460259f27386a8cd
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-backlog-sweep.yml@b24d2cabf9e2244fd4d981f40c91acdac3fd26eb
     with:
       repo_slug: ${{ github.repository }}
       lane: quality

--- a/.github/workflows/quality-zero-backlog.yml
+++ b/.github/workflows/quality-zero-backlog.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-backlog-sweep.yml@6765a29004cf6a156dcb35205795f9c981dd27e8
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-backlog-sweep.yml@bf487f26f816c2033bb848a0122d7f3ea8f804a4
     with:
       repo_slug: ${{ github.repository }}
       lane: quality

--- a/.github/workflows/quality-zero-gate.yml
+++ b/.github/workflows/quality-zero-gate.yml
@@ -16,7 +16,7 @@ jobs:
   aggregate-gate:
     permissions:
       contents: read
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality-zero-gate.yml@b24d2cabf9e2244fd4d981f40c91acdac3fd26eb
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality-zero-gate.yml@6765a29004cf6a156dcb35205795f9c981dd27e8
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-gate.yml
+++ b/.github/workflows/quality-zero-gate.yml
@@ -16,7 +16,7 @@ jobs:
   aggregate-gate:
     permissions:
       contents: read
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality-zero-gate.yml@6765a29004cf6a156dcb35205795f9c981dd27e8
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality-zero-gate.yml@bf487f26f816c2033bb848a0122d7f3ea8f804a4
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-gate.yml
+++ b/.github/workflows/quality-zero-gate.yml
@@ -16,7 +16,7 @@ jobs:
   aggregate-gate:
     permissions:
       contents: read
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality-zero-gate.yml@cc7e3095598478230cd85566a72e310acd1a8923
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality-zero-gate.yml@b24d2cabf9e2244fd4d981f40c91acdac3fd26eb
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-platform.yml
+++ b/.github/workflows/quality-zero-platform.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@cc7e3095598478230cd85566a72e310acd1a8923
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@b24d2cabf9e2244fd4d981f40c91acdac3fd26eb
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-platform.yml
+++ b/.github/workflows/quality-zero-platform.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@6765a29004cf6a156dcb35205795f9c981dd27e8
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@bf487f26f816c2033bb848a0122d7f3ea8f804a4
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-platform.yml
+++ b/.github/workflows/quality-zero-platform.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@b24d2cabf9e2244fd4d981f40c91acdac3fd26eb
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@6765a29004cf6a156dcb35205795f9c981dd27e8
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/quality-zero-remediation.yml
+++ b/.github/workflows/quality-zero-remediation.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-remediation-loop.yml@6765a29004cf6a156dcb35205795f9c981dd27e8
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-remediation-loop.yml@bf487f26f816c2033bb848a0122d7f3ea8f804a4
     with:
       repo_slug: ${{ github.repository }}
       failure_context: Quality Zero Gate

--- a/.github/workflows/quality-zero-remediation.yml
+++ b/.github/workflows/quality-zero-remediation.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-remediation-loop.yml@b24d2cabf9e2244fd4d981f40c91acdac3fd26eb
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-remediation-loop.yml@6765a29004cf6a156dcb35205795f9c981dd27e8
     with:
       repo_slug: ${{ github.repository }}
       failure_context: Quality Zero Gate

--- a/.github/workflows/quality-zero-remediation.yml
+++ b/.github/workflows/quality-zero-remediation.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-remediation-loop.yml@7268fee30f1cf796938d97fe460259f27386a8cd
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-remediation-loop.yml@b24d2cabf9e2244fd4d981f40c91acdac3fd26eb
     with:
       repo_slug: ${{ github.repository }}
       failure_context: Quality Zero Gate

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,3 +7,16 @@ sonar.tests=backend/tests,backend/integration_tests,ui/tests,ui/e2e
 
 sonar.exclusions=**/node_modules/**,**/dist/**,**/.venv/**,**/coverage/**
 sonar.test.inclusions=backend/tests/**,backend/integration_tests/**,ui/tests/**,ui/e2e/**
+
+# Coverage report paths — required so SonarCloud's quality gate can satisfy
+# its ``new_coverage >= 80%`` condition. Without these, the gate showed
+# ``0.0% Coverage on New Code`` even when CI was succeeding (the AutoScan
+# flip resolved the analysis-method conflict, but the coverage data wasn't
+# being pointed at).
+#
+# Paths match the CI workflow's coverage outputs:
+#   backend/coverage.xml             — pytest --cov-report=xml:coverage.xml
+#   ui/coverage/lcov.info            — vitest's default lcov reporter
+#   ui/coverage/cobertura-coverage.xml — vitest cobertura reporter
+sonar.python.coverage.reportPaths=backend/coverage.xml
+sonar.javascript.lcov.reportPaths=ui/coverage/lcov.info

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -157,6 +157,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -516,6 +517,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -559,6 +561,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3840,8 +3843,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3932,6 +3934,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3942,6 +3945,7 @@
       "integrity": "sha512-keKxkZMqnDicuvFoJbzrhbtdLSPhj/rZThDlKWCDbgXmUg0rEUFtRssDXKYmtXluZlIqiC5VqkCgRwzuyLHKHw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3952,6 +3956,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4002,6 +4007,7 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -4666,6 +4672,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4716,7 +4723,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5031,6 +5037,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5494,8 +5501,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5766,6 +5772,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5936,6 +5943,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7287,6 +7295,7 @@
       "integrity": "sha512-GtldT42B8+jefDUC4yUKAvsaOrH7PDHmZxZXNgF2xMmymjUbRYJvpAybZAKEmXDGTM0mCsz8duOa4vTm5AY2Kg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -7689,7 +7698,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8153,6 +8161,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8218,9 +8227,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -8277,7 +8286,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8293,7 +8301,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8346,6 +8353,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8376,6 +8384,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8388,8 +8397,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -9396,6 +9404,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9461,6 +9470,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -9587,6 +9597,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9662,6 +9673,7 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",
@@ -9991,6 +10003,7 @@
       "integrity": "sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -68,6 +68,7 @@
     "vitest": "4.0.16"
   },
   "overrides": {
-    "follow-redirects": "^1.16.0"
+    "follow-redirects": "^1.16.0",
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## **User description**
## Summary

Two fixes that close out the event-link main-green-gate blocker chain.

### 1. postcss security pin — closes Dependabot alert #50

GHSA-qx2v-qp2m-jg93 — PostCSS XSS via unescaped `</style>` (medium). Fix landed in postcss 8.5.10. Added `"postcss": "^8.5.10"` to `ui/package.json -> overrides`. `npm install` regenerated the lockfile; `vite -> postcss` resolves to 8.5.12.

### 2. SonarCloud coverage report paths

Stage 2 of the main-green-gate blocker. After the operator flipped Auto-Analysis off (Stage 1 of the chain — the AutoScan-vs-CI conflict is resolved), the SonarCloud Code Analysis check still failed with `Failed conditions: 0.0% Coverage on New Code`.

Root cause: `sonar-project.properties` had sources / tests / exclusions but **NO** `sonar.python.coverage.reportPaths` or `sonar.javascript.lcov.reportPaths`. The CI workflow generates coverage at `backend/coverage.xml` and `ui/coverage/lcov.info`, but Sonar didn't know where to read it.

Verified via SonarCloud API:
```
GET /api/qualitygates/project_status?projectKey=Prekzursil_event-link
  conditions[].metricKey: new_coverage
  comparator: LT  errorThreshold: 80
  actualValue: "0.0"  status: ERROR
```

Fix: pointed `sonar.python.coverage.reportPaths` and `sonar.javascript.lcov.reportPaths` at the existing artefacts. No workflow change needed.

## Test plan

- [ ] CI runs on this PR
- [ ] `Coverage 100 Gate` step passes (was already passing post-AutoScan-flip)
- [ ] `SonarCloud Code Analysis` check passes (this is the one we're fixing)
- [ ] `Quality Zero Gate` aggregate passes for the first time since QZP rollout
- [ ] After merge, main shows green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `postcss` to the patched 8.5.x line and points SonarCloud at our CI coverage reports to unblock the coverage gate. Also updates all `Prekzursil/quality-zero-platform` reusable workflow pins to the latest `main`.

- **Bug Fixes**
  - Added `sonar.python.coverage.reportPaths=backend/coverage.xml` and `sonar.javascript.lcov.reportPaths=ui/coverage/lcov.info` so SonarCloud reads CI coverage and the `new_coverage` gate evaluates correctly.

- **Dependencies**
  - Pinned `postcss` to `^8.5.10` via `ui/package.json` overrides; lock resolves to `8.5.12` (fixes GHSA-qx2v-qp2m-jg93).
  - Updated `codecov-analytics`, `codeql`, and `quality-zero-*` workflow `uses:` pins to the latest `Prekzursil/quality-zero-platform` `main` to pick up per-flag Codecov and recent platform fixes.

<sup>Written for commit 372c42845c137baf2e94089636f77e2eb8af0818. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Update quality gates and frontend dependencies so CI reports coverage correctly and uses the latest shared workflows**

### What Changed
- SonarCloud now reads the existing backend and frontend coverage reports, so the coverage gate can evaluate real test results instead of showing 0% on new code
- The Quality Zero, CodeQL, Codecov, backlog, and remediation workflows now use the latest shared platform workflow version
- The frontend now pins a safe PostCSS version to avoid the known security issue

### Impact
`✅ SonarCloud coverage checks can pass again`
`✅ Fewer failed quality-gate runs`
`✅ Lower exposure to the PostCSS security issue`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Mu0XCe3eLn9Sv2O1zkhuZ4LNapfbwRzDa_BvnAvYfp4&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
