### PR TITLE
fix(ci): Stage 3 — prefix lcov SF paths with ui/ for SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,19 @@ jobs:
         run: |
           cd ui
           npm test
+      - name: Adjust lcov SF paths for SonarCloud
+        # vitest's v8 coverage provider emits SF: lines relative to its cwd
+        # (``ui/``), so an ``SF:src/components/Foo.tsx`` line ends up looking
+        # for ``src/components/Foo.tsx`` at the SonarCloud project root —
+        # which doesn't exist (the actual file is ``ui/src/components/Foo.tsx``).
+        # Without this prefix step, SonarCloud's ``new_coverage`` quality-gate
+        # condition sees ~65.9% instead of the actual 100% because some files
+        # don't match. Prefixing each SF: line with ``ui/`` makes the paths
+        # repo-root-relative, matching ``sonar.sources=ui/src``.
+        run: |
+          if [ -f ui/coverage/lcov.info ]; then
+            sed -i 's|^SF:|SF:ui/|' ui/coverage/lcov.info
+          fi
       - name: Upload frontend coverage
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
## **User description**
## Stage 3 of the event-link Quality Zero Gate blocker chain

Closes the residual gap between SonarCloud's 65.9% \`new_coverage\` reading and the 100%-tested reality.

### Chain context

- **Stage 1** (resolved): operator flipped SonarCloud Auto-Analysis off → Coverage 100 Gate succeeds
- **Stage 2** (resolved, PR #131): added \`sonar.*.coverage.reportPaths\` → moved Sonar's coverage 0% → 65.9%
- **Stage 3** (this PR): lcov SF: paths are vitest-cwd-relative, not repo-root-relative → fix the mapping

### Root cause

vitest's v8 coverage provider emits lcov \`SF:\` lines relative to where it ran (\`ui/\`):

```
SF:src/components/Foo.tsx
```

SonarCloud joins SF paths against \`sonar.sources\` and the project root. With \`sonar.sources=backend,ui/src,scripts,.github/workflows\`, the matcher looks for \`src/components/Foo.tsx\` at the repo root — which doesn't exist. The real file is \`ui/src/components/Foo.tsx\`.

SonarCloud silently drops unmatched coverage entries. Backend coverage matches fine (pytest-cov writes absolute or src-rooted paths), so we get the partial 65.9% reading.

### Fix

A 3-line CI step prefixes \`ui/\` to every \`SF:\` line in \`ui/coverage/lcov.info\` before the artifact is uploaded:

\`\`\`yaml
- name: Adjust lcov SF paths for SonarCloud
  run: |
    if [ -f ui/coverage/lcov.info ]; then
      sed -i 's|^SF:|SF:ui/|' ui/coverage/lcov.info
    fi
\`\`\`

Idempotent (only runs if the file exists). Doesn't affect Codecov uploads (which run after this step and tolerate either path shape).

### Test plan

- [ ] CI runs on this PR
- [ ] After merge, \`GET /api/qualitygates/project_status?projectKey=Prekzursil_event-link\` shows:
      - \`new_coverage\`: actualValue ≥ 80 (currently 65.9), status OK
      - \`projectStatus.status\`: OK
- [ ] \`shared-scanner-matrix / Sonar Zero\` flips green on event-link main
- [ ] \`Quality Zero Gate\` aggregate goes fully green for the first time since QZP rollout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline coverage data processing to enhance code quality metrics reporting integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefix lcov `SF:` paths with `ui/` in CI so SonarCloud resolves frontend files and counts their coverage. This fixes the 65.9% `new_coverage` reading and should restore the expected 100%, clearing the quality gate.

<sup>Written for commit 9a961824a927b01b0fa5314e97e39296a02f8b88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Fix SonarCloud coverage matching for frontend tests**

### What Changed
- Frontend coverage files now have `ui/` added to each `SF:` path before upload, so SonarCloud can find the tested files correctly
- This prevents SonarCloud from dropping valid frontend coverage and showing a lower coverage result than the real test outcome
- The step only runs when the frontend coverage file exists, so it does not affect other uploads

### Impact
`✅ Accurate SonarCloud coverage for frontend files`
`✅ Fewer false quality-gate failures`
`✅ Clearer coverage results after CI runs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=TqgWNti4sM0YWnThGJ4vGpf_jetrqs-fLznz55oi3iI&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
