### PR TITLE
fix: prefix lcov SF: paths in scripts/verify (QZP gate path)

### DIFF
--- a/scripts/verify
+++ b/scripts/verify
@@ -52,3 +52,17 @@ fi
 rm -rf ui/node_modules
 run_node20 "npm --prefix ui ci"
 run_node20 "npm --prefix ui run test"
+
+# Adjust lcov SF: paths so SonarCloud's path matcher can resolve them.
+# vitest's v8 coverage emits SF: lines relative to its cwd (``ui/``), so
+# entries look like ``SF:src/components/Foo.tsx``. SonarCloud joins SF
+# paths against ``sonar.sources`` and the project root; with
+# ``sonar.sources=ui/src``, the matcher looks for ``src/components/...``
+# at the project root — which doesn't exist. Prefixing each SF: line
+# with ``ui/`` makes the paths repo-root-relative. This step lives in
+# scripts/verify so it runs in BOTH event-link's own CI workflow AND
+# the QZP-managed ``Quality Zero Platform > Coverage 100 Gate > Run
+# selected lane`` step (which calls ``bash scripts/verify``).
+if [ -f ui/coverage/lcov.info ]; then
+  sed -i 's|^SF:|SF:ui/|' ui/coverage/lcov.info
+fi


### PR DESCRIPTION
## **User description**
## Why

PR #132 added the lcov SF: prefix step to \`.github/workflows/ci.yml\`, fixing event-link's own CI workflow. SonarCloud Code Analysis on PR #132 passed because PR-mode quality gates measure only new lines.

But the **main-branch** SonarCloud quality gate evaluates full-codebase coverage. After PR #132 merged, main's Sonar QG still shows \`new_coverage: 65.9%\` because:

1. QZP's \`Quality Zero Platform > Coverage 100 Gate > Run selected lane\` step calls \`bash scripts/verify\`
2. \`scripts/verify\` independently runs \`npm --prefix ui run test\`
3. That produces a *fresh* lcov.info that **overwrites** the path-corrected one from event-link's CI workflow
4. sonar-scanner (next step in same job) reads that overwritten lcov with un-prefixed SF: paths
5. SonarCloud sees ~65.9% match rate

## Fix

Add the same one-line \`sed\` to \`scripts/verify\` so the prefix is applied regardless of which workflow runs frontend tests:

\`\`\`bash
if [ -f ui/coverage/lcov.info ]; then
  sed -i 's|^SF:|SF:ui/|' ui/coverage/lcov.info
fi
\`\`\`

CI's existing step in ci.yml stays — it's a no-op when scripts/verify already prefixed the lcov, but kept for any CI path that produces lcov without invoking scripts/verify.

## Test plan

- [ ] CI runs on this PR
- [ ] After merge, \`GET /api/qualitygates/project_status?projectKey=Prekzursil_event-link\` shows:
      - \`new_coverage\`: actualValue ≥80 (currently 65.9), status OK
      - \`projectStatus.status\`: OK
- [ ] \`shared-scanner-matrix / Sonar Zero\` flips green on event-link main
- [ ] \`Quality Zero Gate\` aggregate goes fully green for the first time since QZP rollout

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefixes lcov `SF:` paths in `scripts/verify` so SonarCloud resolves files correctly, fixing the main-branch Quality Gate when tests run via the QZP path.

- **Bug Fixes**
  - Apply `sed` in `scripts/verify` to rewrite `ui/coverage/lcov.info` lines to `SF:ui/...` after UI tests.
  - Keep the same step in `.github/workflows/ci.yml` to cover CI paths that don’t call `scripts/verify`.

<sup>Written for commit afca92aeeaf31a0c6ea1032b703d2a2f5cb654ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Fix SonarCloud coverage reporting in both CI and the main gate run**

### What Changed
- Coverage reports now keep the correct repository path prefix, so SonarCloud can match test results to source files
- The fix now runs during `scripts/verify`, which covers both the regular CI workflow and the Quality Zero Platform gate path
- This prevents a fresh coverage report from overwriting the path-corrected version with unusable file paths

### Impact
`✅ Higher reported coverage on main`
`✅ Fewer false coverage failures`
`✅ Greener SonarCloud gate checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=GZHArnhPwCECva2b25BM5tqueQwSlPzFy-Y19eqotSs&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
