### PR TITLE
fix(sonar): exclude non-app paths from coverage scope

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,3 +20,29 @@ sonar.test.inclusions=backend/tests/**,backend/integration_tests/**,ui/tests/**,
 #   ui/coverage/cobertura-coverage.xml — vitest cobertura reporter
 sonar.python.coverage.reportPaths=backend/coverage.xml
 sonar.javascript.lcov.reportPaths=ui/coverage/lcov.info
+
+# Coverage scope exclusions — files we want Sonar to scan for *quality* issues
+# (security, complexity, smells) but that are NOT in the test suite's coverage
+# scope. Without this list, Sonar counts these files toward the coverage
+# denominator at 0.0% line coverage each, dragging the project ratio down.
+#
+# Why these are excluded:
+#   scripts/**/*.py            — repo-management devtools (codacy/sonar
+#                                check scripts, sync utilities, docstring
+#                                helpers). Run manually, not by pytest.
+#   backend/scripts/**/*.py    — manually-run admin scripts (ML recompute,
+#                                seed scripts). Not in --cov=app scope.
+#   backend/alembic/versions/**/*.py — auto-generated DB migrations.
+#                                Tested via `alembic upgrade head` integration,
+#                                not via unit tests.
+#   backend/main.py            — FastAPI entry point. The app factory inside
+#                                ``backend/app/`` is what's covered.
+#   backend/seed_data.py       — one-shot seeding script.
+#
+# Diagnostic check: after PR #131 (reportPaths) and PR #132+#133 (lcov SF:
+# prefix), event-link main showed 64.2% line_coverage. SonarCloud's
+# component_tree API confirmed that 100% of the 3468 uncovered lines lived
+# in these four directories — none in ``backend/app/**`` or ``ui/src/**``
+# (both already at 100%). This is a coverage-scope mismatch, not a missing
+# tests problem.
+sonar.coverage.exclusions=scripts/**/*,backend/scripts/**/*,backend/alembic/versions/**/*,backend/main.py,backend/seed_data.py


### PR DESCRIPTION
## **User description**
## Summary

- Add `sonar.coverage.exclusions` for paths intentionally outside the `pytest --cov=app` scope.
- Resolves the residual `new_coverage: 65.94%` ERROR on event-link's SonarCloud Zero quality gate (after PR #131 raised it from 0% and PR #132+#133's lcov SF: prefix attempts had no effect).

## Diagnostic root-cause analysis

After PR #131 (added `sonar.python.coverage.reportPaths` + `sonar.javascript.lcov.reportPaths`) and PR #132+#133 (lcov SF: path remap, applied in both `ci.yml` and `scripts/verify`), event-link main still showed:

| Metric | Value |
|---|---|
| `coverage` | 70.3 |
| `branch_coverage` | 100.0 |
| `line_coverage` | 64.2 |
| `new_coverage` | 65.94 (**ERROR**, gate threshold 80%) |
| `uncovered_lines` | 3468 / 9696 |

Querying SonarCloud's `api/measures/component_tree` for uncovered lines revealed that **100% of those 3468 uncovered lines** live in four directories — none of them in `backend/app/**` or `ui/src/**` (both at 100% line coverage):

| Directory | Uncovered lines |
|---|---|
| `scripts/quality/**` | 1474 |
| `backend/scripts/**` | 810 |
| `scripts/**` (other) | 703 |
| `backend/alembic/**` | 481 |
| **Total** | **3468** ✓ |

So the previous lcov SF: prefix hypothesis was wrong: the issue was never path mapping. Sonar was correctly counting these files; they're just not in the test suite's scope:

- `scripts/quality/**` and `scripts/**` — repo-management devtools (codacy/sonar zero-check scripts, sync utilities, docstring helpers). Run manually, not by pytest.
- `backend/scripts/**` — manually-run admin scripts (ML recompute, seed). Not in `--cov=app`.
- `backend/alembic/versions/**` — auto-generated DB migrations. Tested via `alembic upgrade head` integration, not unit tests.
- `backend/main.py` / `backend/seed_data.py` — FastAPI entry / one-shot seeding script.

Using `sonar.coverage.exclusions` (not `sonar.exclusions`) keeps them in scope for quality scanning (security/complexity/smells) while removing them from the coverage denominator.

## Expected outcome

- `new_coverage` rises from 65.94% → ≥80% (the actual app code is at 100%; only ratio normalization is needed).
- SonarCloud Zero quality gate flips ERROR → OK on event-link main.
- No change to scanning surface for security / quality issues.

## Test plan

- [ ] CI green on this PR (backend, frontend, integration, e2e, docker).
- [ ] After merge, re-query `api/measures/component?component=Prekzursil_event-link&metricKeys=new_coverage,line_coverage,coverage` and confirm `new_coverage >= 80`.
- [ ] Confirm SonarCloud quality-gate status flips to OK on event-link main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude non-app paths from Sonar coverage to align with the test scope and clear the failing quality gate. Keeps these files scanned for quality, but removes them from the coverage denominator.

- **Bug Fixes**
  - Added `sonar.coverage.exclusions` for: `scripts/**/*`, `backend/scripts/**/*`, `backend/alembic/versions/**/*`, `backend/main.py`, `backend/seed_data.py`.
  - These are outside `pytest --cov=app` (manual tools, admin scripts, migrations, entry/seed). Still scanned for security and smells, just not counted in coverage.
  - Expected: `new_coverage` rises from 65.94% to ≥80% and the SonarCloud Zero gate passes.

<sup>Written for commit d91af45569dd2e23f025df28939d2883f7bbdd52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Exclude non-tested project files from Sonar coverage**

### What Changed
- Sonar no longer counts manual scripts, database migrations, the main app entry file, and the one-off seed script as part of test coverage
- These files still stay in Sonar scans for code quality issues, but they no longer drag down the coverage score
- This fixes the low new-code coverage result caused by files that are outside the test suite’s scope

### Impact
`✅ Higher Sonar coverage on new code`
`✅ Fewer false coverage failures`
`✅ Cleaner quality gate results`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Iogbafk3WDkJ_a43KkjeNh7YFE4uPgBtLBM7CdhhEH8&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
