### PR TITLE
fix(sonar): clear 39 code-smells + 2 security hotspots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,10 @@ jobs:
       - name: Install frontend deps
         run: |
           cd ui
-          npm ci
+          # --ignore-scripts: don't auto-run package lifecycle scripts on
+          # install (githubactions:S6505 hotspot mitigation). The build
+          # commands we need run via npm test / npm run build below.
+          npm ci --ignore-scripts
       - name: Run frontend checks
         run: |
           cd ui
@@ -251,7 +254,10 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
         run: |
           cd ui
-          npm ci
+          # --ignore-scripts: don't auto-run package lifecycle scripts on
+          # install (githubactions:S6505 hotspot mitigation). The build
+          # commands we need run via npm test / npm run build below.
+          npm ci --ignore-scripts
       - name: Install Playwright (Chromium)
         run: |
           cd ui

--- a/.github/workflows/quality-zero-platform.yml
+++ b/.github/workflows/quality-zero-platform.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@bf487f26f816c2033bb848a0122d7f3ea8f804a4
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-scanner-matrix.yml@f73f84128d79a1160b766579abb690543b6bf6b7
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,3 +20,29 @@ sonar.test.inclusions=backend/tests/**,backend/integration_tests/**,ui/tests/**,
 #   ui/coverage/cobertura-coverage.xml — vitest cobertura reporter
 sonar.python.coverage.reportPaths=backend/coverage.xml
 sonar.javascript.lcov.reportPaths=ui/coverage/lcov.info
+
+# Coverage scope exclusions — files we want Sonar to scan for *quality* issues
+# (security, complexity, smells) but that are NOT in the test suite's coverage
+# scope. Without this list, Sonar counts these files toward the coverage
+# denominator at 0.0% line coverage each, dragging the project ratio down.
+#
+# Why these are excluded:
+#   scripts/**/*.py            — repo-management devtools (codacy/sonar
+#                                check scripts, sync utilities, docstring
+#                                helpers). Run manually, not by pytest.
+#   backend/scripts/**/*.py    — manually-run admin scripts (ML recompute,
+#                                seed scripts). Not in --cov=app scope.
+#   backend/alembic/versions/**/*.py — auto-generated DB migrations.
+#                                Tested via `alembic upgrade head` integration,
+#                                not via unit tests.
+#   backend/main.py            — FastAPI entry point. The app factory inside
+#                                ``backend/app/`` is what's covered.
+#   backend/seed_data.py       — one-shot seeding script.
+#
+# Diagnostic check: after PR #131 (reportPaths) and PR #132+#133 (lcov SF:
+# prefix), event-link main showed 64.2% line_coverage. SonarCloud's
+# component_tree API confirmed that 100% of the 3468 uncovered lines lived
+# in these four directories — none in ``backend/app/**`` or ``ui/src/**``
+# (both already at 100%). This is a coverage-scope mismatch, not a missing
+# tests problem.
+sonar.coverage.exclusions=scripts/**/*,backend/scripts/**/*,backend/alembic/versions/**/*,backend/main.py,backend/seed_data.py

--- a/ui/src/components/layout/Footer.tsx
+++ b/ui/src/components/layout/Footer.tsx
@@ -1,6 +1,27 @@
+import type * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Calendar, Github, Mail } from 'lucide-react';
+import { Calendar, Mail } from 'lucide-react';
 import { useI18n } from '@/contexts/LanguageContext';
+
+// Inline GitHub mark — lucide-react's Github icon is deprecated as of
+// 0.x with no built-in replacement (see lucide-icons/lucide#670). Render
+// the official GitHub mark inline so we don't pull in an extra brand-icon
+// package just for the footer link.
+function GithubIcon(props: Readonly<React.SVGProps<SVGSVGElement>>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      width="24"
+      height="24"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M12 .5C5.73.5.66 5.57.66 11.85c0 5.02 3.26 9.27 7.78 10.78.57.1.78-.25.78-.55v-2c-3.16.69-3.83-1.36-3.83-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.24 3.34.95.1-.74.4-1.24.72-1.52-2.52-.29-5.18-1.26-5.18-5.6 0-1.24.44-2.25 1.16-3.04-.12-.29-.5-1.45.11-3.02 0 0 .96-.31 3.13 1.16a10.85 10.85 0 0 1 5.7 0c2.17-1.47 3.13-1.16 3.13-1.16.61 1.57.23 2.73.11 3.02.72.79 1.16 1.8 1.16 3.04 0 4.35-2.66 5.31-5.19 5.59.41.35.78 1.03.78 2.08v3.08c0 .3.21.65.78.55a11.36 11.36 0 0 0 7.78-10.78C23.34 5.57 18.27.5 12 .5z" />
+    </svg>
+  );
+}
 
 type QuickLinkItem = Readonly<{
   href: string;
@@ -9,7 +30,10 @@ type QuickLinkItem = Readonly<{
 
 type ContactLinkItem = Readonly<{
   href: string;
-  icon: typeof Calendar;
+  // icon accepts both lucide-react ForwardRefExoticComponents (e.g.
+  // typeof Calendar) and our inline GithubIcon component, which is a
+  // plain functional component with className/SVG props.
+  icon: React.ComponentType<{ className?: string } & React.SVGProps<SVGSVGElement>>;
   label: string;
 }>;
 
@@ -110,7 +134,7 @@ export function Footer() {
   ];
   const contactLinks: ContactLinkItem[] = [
     { href: 'mailto:contact@eventlink.ro', icon: Mail, label: 'contact@eventlink.ro' },
-    { href: 'https://github.com/Prekzursil/event-link', icon: Github, label: 'GitHub' },
+    { href: 'https://github.com/Prekzursil/event-link', icon: GithubIcon, label: 'GitHub' },
   ];
 
   return (

--- a/ui/src/components/layout/Footer.tsx
+++ b/ui/src/components/layout/Footer.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react';
+import type { ComponentType, SVGProps } from 'react';
 import { Link } from 'react-router-dom';
 import { Calendar, Mail } from 'lucide-react';
 import { useI18n } from '@/contexts/LanguageContext';
@@ -7,7 +7,7 @@ import { useI18n } from '@/contexts/LanguageContext';
 // 0.x with no built-in replacement (see lucide-icons/lucide#670). Render
 // the official GitHub mark inline so we don't pull in an extra brand-icon
 // package just for the footer link.
-function GithubIcon(props: Readonly<React.SVGProps<SVGSVGElement>>) {
+function GithubIcon(props: Readonly<SVGProps<SVGSVGElement>>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -33,7 +33,7 @@ type ContactLinkItem = Readonly<{
   // icon accepts both lucide-react ForwardRefExoticComponents (e.g.
   // typeof Calendar) and our inline GithubIcon component, which is a
   // plain functional component with className/SVG props.
-  icon: React.ComponentType<{ className?: string } & React.SVGProps<SVGSVGElement>>;
+  icon: ComponentType<{ className?: string } & SVGProps<SVGSVGElement>>;
   label: string;
 }>;
 

--- a/ui/src/components/ui/avatar.tsx
+++ b/ui/src/components/ui/avatar.tsx
@@ -4,7 +4,7 @@ import { Root, Image, Fallback } from "@radix-ui/react-avatar"
 import { cn } from "@/lib/utils"
 
 const Avatar = React.forwardRef<
-  React.ElementRef<typeof Root>,
+  React.ComponentRef<typeof Root>,
   React.ComponentPropsWithoutRef<typeof Root>
 >(({ className, ...props }, ref) => (
   <Root
@@ -19,7 +19,7 @@ const Avatar = React.forwardRef<
 Avatar.displayName = Root.displayName
 
 const AvatarImage = React.forwardRef<
-  React.ElementRef<typeof Image>,
+  React.ComponentRef<typeof Image>,
   React.ComponentPropsWithoutRef<typeof Image>
 >(({ className, ...props }, ref) => (
   <Image
@@ -31,7 +31,7 @@ const AvatarImage = React.forwardRef<
 AvatarImage.displayName = Image.displayName
 
 const AvatarFallback = React.forwardRef<
-  React.ElementRef<typeof Fallback>,
+  React.ComponentRef<typeof Fallback>,
   React.ComponentPropsWithoutRef<typeof Fallback>
 >(({ className, ...props }, ref) => (
   <Fallback

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -30,7 +30,7 @@ export interface BadgeProps
 /**
  * Test helper: badge.
  */
-function Badge({ className, variant, ...props }: BadgeProps) {
+function Badge({ className, variant, ...props }: Readonly<BadgeProps>) {
   return (
     <div className={cn(badgeVariants({ variant }), className)} {...props} />
   )

--- a/ui/src/components/ui/checkbox.tsx
+++ b/ui/src/components/ui/checkbox.tsx
@@ -5,7 +5,7 @@ import { Check } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const Checkbox = React.forwardRef<
-  React.ElementRef<typeof Root>,
+  React.ComponentRef<typeof Root>,
   React.ComponentPropsWithoutRef<typeof Root>
 >(({ className, ...props }, ref) => (
   <Root

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -27,7 +27,7 @@ const DialogClose = Close
 
 /** Dimmed backdrop rendered behind the dialog surface. */
 const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof Overlay>,
+  React.ComponentRef<typeof Overlay>,
   React.ComponentPropsWithoutRef<typeof Overlay>
 >(({ className, ...props }, ref) => (
   <Overlay
@@ -43,7 +43,7 @@ DialogOverlay.displayName = Overlay.displayName
 
 /** Modal content surface with the built-in close button. */
 const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitiveContent>,
+  React.ComponentRef<typeof DialogPrimitiveContent>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitiveContent>
 >(({ className, children, ...props }, ref) => (
   <DialogPortal>
@@ -98,7 +98,7 @@ DialogFooter.displayName = "DialogFooter"
 
 /** Accessible dialog heading. */
 const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitiveTitle>,
+  React.ComponentRef<typeof DialogPrimitiveTitle>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitiveTitle>
 >(({ className, ...props }, ref) => (
   <DialogPrimitiveTitle
@@ -114,7 +114,7 @@ DialogTitle.displayName = DialogPrimitiveTitle.displayName
 
 /** Accessible dialog description. */
 const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitiveDescription>,
+  React.ComponentRef<typeof DialogPrimitiveDescription>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitiveDescription>
 >(({ className, ...props }, ref) => (
   <DialogPrimitiveDescription

--- a/ui/src/components/ui/dropdown-menu.tsx
+++ b/ui/src/components/ui/dropdown-menu.tsx
@@ -38,7 +38,7 @@ const DropdownMenuRadioGroup = RadioGroup
 
 /** Sub-menu trigger with a chevron affordance. */
 const DropdownMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof SubTrigger>,
+  React.ComponentRef<typeof SubTrigger>,
   React.ComponentPropsWithoutRef<typeof SubTrigger> & {
     inset?: boolean
   }
@@ -61,7 +61,7 @@ DropdownMenuSubTrigger.displayName =
 
 /** Sub-menu panel for nested menus. */
 const DropdownMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof SubContent>,
+  React.ComponentRef<typeof SubContent>,
   React.ComponentPropsWithoutRef<typeof SubContent>
 >(({ className, ...props }, ref) => (
   <SubContent
@@ -78,7 +78,7 @@ DropdownMenuSubContent.displayName =
 
 /** Top-level dropdown-menu panel. */
 const DropdownMenuContent = React.forwardRef<
-  React.ElementRef<typeof DmContent>,
+  React.ComponentRef<typeof DmContent>,
   React.ComponentPropsWithoutRef<typeof DmContent>
 >(({ className, sideOffset = 4, ...props }, ref) => (
   <Portal>
@@ -98,7 +98,7 @@ DropdownMenuContent.displayName = DmContent.displayName
 
 /** Interactive dropdown-menu row. */
 const DropdownMenuItem = React.forwardRef<
-  React.ElementRef<typeof DmItem>,
+  React.ComponentRef<typeof DmItem>,
   React.ComponentPropsWithoutRef<typeof DmItem> & {
     inset?: boolean
   }
@@ -117,7 +117,7 @@ DropdownMenuItem.displayName = DmItem.displayName
 
 /** Checkbox-state dropdown-menu row. */
 const DropdownMenuCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof CheckboxItem>,
+  React.ComponentRef<typeof CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
   <CheckboxItem
@@ -142,7 +142,7 @@ DropdownMenuCheckboxItem.displayName =
 
 /** Radio-group dropdown-menu row. */
 const DropdownMenuRadioItem = React.forwardRef<
-  React.ElementRef<typeof RadioItem>,
+  React.ComponentRef<typeof RadioItem>,
   React.ComponentPropsWithoutRef<typeof RadioItem>
 >(({ className, children, ...props }, ref) => (
   <RadioItem
@@ -165,7 +165,7 @@ DropdownMenuRadioItem.displayName = RadioItem.displayName
 
 /** Non-interactive dropdown-menu section label. */
 const DropdownMenuLabel = React.forwardRef<
-  React.ElementRef<typeof DmLabel>,
+  React.ComponentRef<typeof DmLabel>,
   React.ComponentPropsWithoutRef<typeof DmLabel> & {
     inset?: boolean
   }
@@ -184,7 +184,7 @@ DropdownMenuLabel.displayName = DmLabel.displayName
 
 /** Horizontal divider for dropdown-menu groups. */
 const DropdownMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof DmSeparator>,
+  React.ComponentRef<typeof DmSeparator>,
   React.ComponentPropsWithoutRef<typeof DmSeparator>
 >(({ className, ...props }, ref) => (
   <DmSeparator

--- a/ui/src/components/ui/label.tsx
+++ b/ui/src/components/ui/label.tsx
@@ -9,7 +9,7 @@ const labelVariants = cva(
 )
 
 const Label = React.forwardRef<
-  React.ElementRef<typeof Root>,
+  React.ComponentRef<typeof Root>,
   React.ComponentPropsWithoutRef<typeof Root> &
     VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (

--- a/ui/src/components/ui/popover.tsx
+++ b/ui/src/components/ui/popover.tsx
@@ -10,7 +10,7 @@ const PopoverTrigger = Trigger
 const PopoverAnchor = Anchor
 
 const PopoverContent = React.forwardRef<
-  React.ElementRef<typeof Content>,
+  React.ComponentRef<typeof Content>,
   React.ComponentPropsWithoutRef<typeof Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
   <Portal>

--- a/ui/src/components/ui/select.tsx
+++ b/ui/src/components/ui/select.tsx
@@ -27,7 +27,7 @@ const SelectGroup = Group
 const SelectValue = Value
 
 const SelectTrigger = React.forwardRef<
-  React.ElementRef<typeof Trigger>,
+  React.ComponentRef<typeof Trigger>,
   React.ComponentPropsWithoutRef<typeof Trigger>
 >(({ className, children, ...props }, ref) => (
   <Trigger
@@ -47,7 +47,7 @@ const SelectTrigger = React.forwardRef<
 SelectTrigger.displayName = Trigger.displayName
 
 const SelectScrollUpButton = React.forwardRef<
-  React.ElementRef<typeof ScrollUpButton>,
+  React.ComponentRef<typeof ScrollUpButton>,
   React.ComponentPropsWithoutRef<typeof ScrollUpButton>
 >(({ className, ...props }, ref) => (
   <ScrollUpButton
@@ -64,7 +64,7 @@ const SelectScrollUpButton = React.forwardRef<
 SelectScrollUpButton.displayName = ScrollUpButton.displayName
 
 const SelectScrollDownButton = React.forwardRef<
-  React.ElementRef<typeof ScrollDownButton>,
+  React.ComponentRef<typeof ScrollDownButton>,
   React.ComponentPropsWithoutRef<typeof ScrollDownButton>
 >(({ className, ...props }, ref) => (
   <ScrollDownButton
@@ -82,7 +82,7 @@ SelectScrollDownButton.displayName =
   ScrollDownButton.displayName
 
 const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitiveContent>,
+  React.ComponentRef<typeof SelectPrimitiveContent>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitiveContent>
 >(({ className, children, position = "popper", ...props }, ref) => (
   <Portal>
@@ -114,7 +114,7 @@ const SelectContent = React.forwardRef<
 SelectContent.displayName = SelectPrimitiveContent.displayName
 
 const SelectLabel = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitiveLabel>,
+  React.ComponentRef<typeof SelectPrimitiveLabel>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitiveLabel>
 >(({ className, ...props }, ref) => (
   <SelectPrimitiveLabel
@@ -126,7 +126,7 @@ const SelectLabel = React.forwardRef<
 SelectLabel.displayName = SelectPrimitiveLabel.displayName
 
 const SelectItem = React.forwardRef<
-  React.ElementRef<typeof Item>,
+  React.ComponentRef<typeof Item>,
   React.ComponentPropsWithoutRef<typeof Item>
 >(({ className, children, ...props }, ref) => (
   <Item
@@ -148,7 +148,7 @@ const SelectItem = React.forwardRef<
 SelectItem.displayName = Item.displayName
 
 const SelectSeparator = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitiveSeparator>,
+  React.ComponentRef<typeof SelectPrimitiveSeparator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitiveSeparator>
 >(({ className, ...props }, ref) => (
   <SelectPrimitiveSeparator

--- a/ui/src/components/ui/separator.tsx
+++ b/ui/src/components/ui/separator.tsx
@@ -4,7 +4,7 @@ import { Root } from "@radix-ui/react-separator"
 import { cn } from "@/lib/utils"
 
 const Separator = React.forwardRef<
-  React.ElementRef<typeof Root>,
+  React.ComponentRef<typeof Root>,
   React.ComponentPropsWithoutRef<typeof Root>
 >(
   (

--- a/ui/src/components/ui/skeleton.tsx
+++ b/ui/src/components/ui/skeleton.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 /**
  * Test helper: skeleton.
  */
-export function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+export function Skeleton({ className, ...props }: Readonly<React.HTMLAttributes<HTMLDivElement>>) {
   return <div className={cn('animate-pulse rounded-md bg-muted', className)} {...props} />;
 }
 

--- a/ui/src/components/ui/tabs.tsx
+++ b/ui/src/components/ui/tabs.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils"
 const Tabs = Root
 
 const TabsList = React.forwardRef<
-  React.ElementRef<typeof List>,
+  React.ComponentRef<typeof List>,
   React.ComponentPropsWithoutRef<typeof List>
 >(({ className, ...props }, ref) => (
   <List
@@ -21,7 +21,7 @@ const TabsList = React.forwardRef<
 TabsList.displayName = List.displayName
 
 const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof Trigger>,
+  React.ComponentRef<typeof Trigger>,
   React.ComponentPropsWithoutRef<typeof Trigger>
 >(({ className, ...props }, ref) => (
   <Trigger
@@ -36,7 +36,7 @@ const TabsTrigger = React.forwardRef<
 TabsTrigger.displayName = Trigger.displayName
 
 const TabsContent = React.forwardRef<
-  React.ElementRef<typeof Content>,
+  React.ComponentRef<typeof Content>,
   React.ComponentPropsWithoutRef<typeof Content>
 >(({ className, ...props }, ref) => (
   <Content

--- a/ui/src/components/ui/toast.tsx
+++ b/ui/src/components/ui/toast.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils"
 const ToastProvider = Provider
 
 const ToastViewport = React.forwardRef<
-  React.ElementRef<typeof Viewport>,
+  React.ComponentRef<typeof Viewport>,
   React.ComponentPropsWithoutRef<typeof Viewport>
 >(({ className, ...props }, ref) => (
   <Viewport
@@ -48,7 +48,7 @@ const toastVariants = cva(
 )
 
 const Toast = React.forwardRef<
-  React.ElementRef<typeof Root>,
+  React.ComponentRef<typeof Root>,
   React.ComponentPropsWithoutRef<typeof Root> &
     VariantProps<typeof toastVariants>
 >(({ className, variant, ...props }, ref) => {
@@ -63,7 +63,7 @@ const Toast = React.forwardRef<
 Toast.displayName = Root.displayName
 
 const ToastAction = React.forwardRef<
-  React.ElementRef<typeof Action>,
+  React.ComponentRef<typeof Action>,
   React.ComponentPropsWithoutRef<typeof Action>
 >(({ className, ...props }, ref) => (
   <Action
@@ -78,7 +78,7 @@ const ToastAction = React.forwardRef<
 ToastAction.displayName = Action.displayName
 
 const ToastClose = React.forwardRef<
-  React.ElementRef<typeof Close>,
+  React.ComponentRef<typeof Close>,
   React.ComponentPropsWithoutRef<typeof Close>
 >(({ className, ...props }, ref) => (
   <Close
@@ -96,7 +96,7 @@ const ToastClose = React.forwardRef<
 ToastClose.displayName = Close.displayName
 
 const ToastTitle = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitiveTitle>,
+  React.ComponentRef<typeof ToastPrimitiveTitle>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitiveTitle>
 >(({ className, ...props }, ref) => (
   <ToastPrimitiveTitle
@@ -108,7 +108,7 @@ const ToastTitle = React.forwardRef<
 ToastTitle.displayName = ToastPrimitiveTitle.displayName
 
 const ToastDescription = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitiveDescription>,
+  React.ComponentRef<typeof ToastPrimitiveDescription>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitiveDescription>
 >(({ className, ...props }, ref) => (
   <ToastPrimitiveDescription


### PR DESCRIPTION
## **User description**
Source-fixes for every visible Sonar finding on event-link main:

- 35x typescript:S1874 — replace deprecated React.ElementRef with React.ComponentRef in shadcn/ui radix wrappers
- 2x typescript:S1874 — replace deprecated lucide-react Github icon with inline GitHub mark SVG
- 2x typescript:S6759 — wrap Badge/Skeleton component props in Readonly<>
- 2x githubactions:S6505 (security hotspots) — pass --ignore-scripts to npm ci in CI

Drops Sonar issue count 39 → 0 and hotspot count 2 → 0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears all Sonar findings: 39 code smells and 2 security hotspots. Also resolves a DeepSource import antipattern in the footer.

- **Refactors**
  - Replace React.ElementRef with React.ComponentRef across Radix UI wrappers to remove deprecations.
  - Inline GitHub mark SVG in the footer to replace the deprecated `lucide-react` Github icon.
  - Mark `Badge` and `Skeleton` props as Readonly to satisfy immutability rules.
  - Footer: switch wildcard React type import to named imports (`ComponentType`, `SVGProps`) to satisfy DeepSource.

- **Bug Fixes**
  - CI: add `--ignore-scripts` to `npm ci` to resolve `githubactions:S6505` hotspots.
  - Sonar: exclude scripts/admin/migration entry points from the coverage denominator (kept in quality scan). Coverage rises from ~66% to ≥80%, restoring the quality gate.
  - Quality scanning: bump `Prekzursil/quality-zero-platform` reusable workflow SHA to include Sonar Zero gate fixes and retries.

<sup>Written for commit c4d56ce115436617b63da2a7233a852f46dcb29a. Summary will update on new commits. <a href="https://cubic.dev/pr/Prekzursil/event-link/pull/135?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Update the footer GitHub link and refresh UI wrappers for current dependencies

### What Changed
- The footer now shows the GitHub mark as an inline icon instead of the deprecated branded icon
- Dropdowns, dialogs, tabs, selects, toasts, avatars, labels, checkboxes, popovers, separators, badges, and skeletons were updated to keep the app working with current React and Radix types
- CI installs now skip package scripts during dependency setup to reduce install-time risk
- Sonar coverage now ignores scripts, migrations, and other manual-run files so quality checks focus on the app code that is actually tested

### Impact
`✅ Clearer footer social links`
`✅ Fewer install-time security risks`
`✅ Stable quality checks on app code`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=mU7WYxSarIQb-12rgYy05-rA4FUer9yn0iHxkZcrrkM&org=Prekzursil)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated GitHub icon appearance in the footer.

* **Chores**
  * Enhanced CI workflow security measures.
  * Modified code coverage exclusion configuration.
  * Improved TypeScript type definitions across UI components for better development compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->