### PR TITLE
fix(deps): clear all 20 axios alerts + remaining npm CVEs (deps gate 21 -> 0 findings)

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -12,6 +12,14 @@
 #   - backend/requirements-dev.txt  (Python backend dev/test deps)
 #   - ui/package-lock.json          (React/Vite TypeScript UI npm tree)
 #
+# SCHEMA WARNING: [[IgnoredVulns]] accepts ONLY the keys `id`, `ignoreUntil`
+# (a bare, UNQUOTED date) and `reason`. Any unknown key makes osv-scanner
+# silently reject the ENTIRE file and fall back to an empty config — which
+# disables the ignore list while still appearing to work. After editing, prove
+# the file still parses (exit 130 means it is broken) and confirm the ignores
+# are actually applied by looking for the "Filtered N vulnerabilities from
+# output" line in the scan output.
+#
 # ---------------------------------------------------------------------------
 # GAP CLOSED (2026-06-20): the actionable CVEs noted earlier (axios,
 # react-router, vite, vitest, esbuild, form-data, ws, @babel/core, js-yaml
@@ -25,3 +33,24 @@
 # for a future vuln that is genuinely unfixable or provably unreachable — do
 # NOT use ignores to paper over an available upgrade.
 # ---------------------------------------------------------------------------
+#
+# ---------------------------------------------------------------------------
+# UPDATE (2026-07-25): a new wave of npm advisories took the tree to 21
+# findings across 6 packages. 19 of the 21 were cleared by UPGRADING, per the
+# policy above, and only the 2 below — which have no non-breaking fix — are
+# ignored. Upgrades applied: axios 1.16.0 -> 1.18.1 (clears 10 advisories and
+# all 20 open Dependabot alerts), react-router-dom 7.15.1 -> 7.18.1 (clears 4),
+# overrides.brace-expansion -> ^2.1.2 (clears GHSA-3jxr-9vmj-r5cp on both the
+# 1.x and 2.x lines), postcss -> 8.5.23 and js-yaml -> 4.3.0 (both already
+# permitted by their existing overrides ranges, lock refresh only).
+# ---------------------------------------------------------------------------
+
+[[IgnoredVulns]]
+id = "GHSA-mh99-v99m-4gvg"
+ignoreUntil = 2026-10-23
+reason = "brace-expansion: DoS via unbounded expansion length. GENUINELY UNFIXABLE right now — the advisory range is <= 5.0.7 and the only patched release is 5.0.8, a MAJOR bump its own consumers cannot take. MEASURED in this repo 2026-07-25: setting overrides.brace-expansion to ^5.0.8 installs cleanly but eslint then dies with 'TypeError: expand is not a function' at minimatch/minimatch.js:271, because minimatch 3.x and 9.x cannot consume the 5.x export shape. SCOPE MEASURED — dev-only: 'npm ls brace-expansion --all --omit=dev' returns empty and both lockfile entries carry dev=true; the only consumers are eslint-plugin-import -> minimatch@3.1.5 and typescript-eslint -> @typescript-eslint/typescript-estree -> minimatch@9.0.9, so it executes at lint time and never ships in the browser bundle. What WAS fixable is fixed, not suppressed: overrides pins brace-expansion ^2.1.2, clearing GHSA-3jxr-9vmj-r5cp on both lines. RE-CHECK: drop this entry once minimatch (or another consumer) ships a release that accepts brace-expansion 5.x, then remove the ^2.1.2 override and take 5.0.8+."
+
+[[IgnoredVulns]]
+id = "GHSA-qwww-vcr4-c8h2"
+ignoreUntil = 2026-10-23
+reason = "React Router: RSC-mode CSRF bypass allows action execution. NOT REACHABLE IN THIS PRODUCT — the advisory affects React Router's unstable RSC APIs, and its range >= 7.12.0, < 8.3.0 has NO 7.x fix at all (first patched 8.3.0, a major framework migration that dependabot.yml also excludes via version-update:semver-major). SCOPE MEASURED over ui/src 2026-07-25: this is a plain Vite SPA on the DECLARATIVE router only — BrowserRouter, Routes, Route, Navigate, Link, Outlet, useNavigate, useLocation, useSearchParams. Zero data-router/action surface (no createBrowserRouter, RouterProvider, createRoutesFromElements, loader, action, useFetcher, useSubmit, useLoaderData, useActionData, no unstable_ API) and zero SSR/RSC surface (no renderToString, renderToPipeableStream, hydrateRoot, react-server, entry.server, @react-router/node|serve|dev). What WAS fixable is fixed, not suppressed: react-router-dom pinned to 7.18.1, clearing GHSA-337j-9hxr-rhxg, GHSA-chx6-hx7r-mcp5, GHSA-h8fp-f39c-q6mh and GHSA-wrjc-x8rr-h8h6. RE-CHECK: drop this entry if a 7.x backport ships, or immediately if this app adopts RSC, SSR or a data router (createBrowserRouter / RouterProvider / loaders / actions) — at which point react-router must go to 8.3.0+."

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -28,7 +28,7 @@
         "react": "19.2.0",
         "react-day-picker": "9.12.0",
         "react-dom": "19.2.0",
-        "react-router-dom": "7.15.1",
+        "react-router-dom": "7.18.1",
         "tailwind-merge": "3.4.0",
         "tailwindcss": "4.1.18"
       },
@@ -4146,16 +4146,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -5018,14 +5008,13 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -5234,13 +5223,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -7283,9 +7265,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -7882,9 +7864,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -8247,9 +8229,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -8266,7 +8248,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8478,9 +8460,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
-      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -8500,12 +8482,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.1.tgz",
-      "integrity": "sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.15.1"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -20,7 +20,7 @@
         "@radix-ui/react-tabs": "1.1.13",
         "@radix-ui/react-toast": "1.2.15",
         "@tailwindcss/vite": "4.1.18",
-        "axios": "^1.18.0",
+        "axios": "1.18.1",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "date-fns": "4.1.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -20,7 +20,7 @@
         "@radix-ui/react-tabs": "1.1.13",
         "@radix-ui/react-toast": "1.2.15",
         "@tailwindcss/vite": "4.1.18",
-        "axios": "1.16.0",
+        "axios": "^1.18.0",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "date-fns": "4.1.0",
@@ -4951,14 +4951,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {
@@ -5382,7 +5408,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7854,7 +7879,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-tabs": "1.1.13",
     "@radix-ui/react-toast": "1.2.15",
     "@tailwindcss/vite": "4.1.18",
-    "axios": "1.16.0",
+    "axios": "^1.18.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "date-fns": "4.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,7 +40,7 @@
     "react": "19.2.0",
     "react-day-picker": "9.12.0",
     "react-dom": "19.2.0",
-    "react-router-dom": "7.15.1",
+    "react-router-dom": "7.18.1",
     "tailwind-merge": "3.4.0",
     "tailwindcss": "4.1.18"
   },
@@ -75,6 +75,7 @@
     "form-data": "^4.0.6",
     "ws": "^8.21.0",
     "@babel/core": "^7.29.6",
+    "brace-expansion": "^2.1.2",
     "js-yaml": "^4.2.0"
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-tabs": "1.1.13",
     "@radix-ui/react-toast": "1.2.15",
     "@tailwindcss/vite": "4.1.18",
-    "axios": "^1.18.0",
+    "axios": "1.18.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "date-fns": "4.1.0",


### PR DESCRIPTION
## What

Clears **all 20 open Dependabot alerts** (axios) and takes the `osv-scanner` deps gate from **21 findings / 6 packages to 0 actionable findings**.

19 of the 21 are cleared by **upgrading**. Only the 2 with no non-breaking fix are ignored, each dated and individually justified against *this* tree.

| Change | Clears |
|---|---|
| `axios` 1.16.0 -> **1.18.1** | 10 advisories = **all 20 open Dependabot alerts** (2 high / 18 moderate) |
| `react-router-dom` 7.15.1 -> **7.18.1** | GHSA-337j-9hxr-rhxg, GHSA-chx6-hx7r-mcp5 (8.7 high), GHSA-h8fp-f39c-q6mh, GHSA-wrjc-x8rr-h8h6 |
| `overrides.brace-expansion` -> **^2.1.2** | GHSA-3jxr-9vmj-r5cp, on **both** the 1.x and 2.x lines |
| `postcss` 8.5.12 -> **8.5.23** | GHSA-r28c-9q8g-f849 |
| `js-yaml` 4.2.0 -> **4.3.0** | GHSA-52cp-r559-cp3m |

`postcss` and `js-yaml` needed no manifest edit — both were already permitted by their existing `overrides` ranges (`^8.5.10`, `^4.2.0`) and only wanted a lock refresh.

## The Dependabot alert pool collapses to one bump

All 20 open alerts are `axios`: **10 distinct GHSAs x 2 manifests** (`ui/package.json`, `ui/package-lock.json`). Counted four mechanically independent ways, all agreeing on 20: REST `dependabot/alerts` with `--paginate`; GraphQL `vulnerabilityAlerts` (`totalCount: 20`, `HIGH: 2`, `MODERATE: 18`); osv-scanner; and GitHub's own push hook.

Every advisory was checked against **its own** `vulnerable_version_range`, not just its reported `first_patched_version`. Four of the ten carry a second, disjoint **0.x** range (e.g. GHSA-7q8q = `>= 0.8.0, < 0.33.0` **and** `>= 1.0.0, < 1.18.0`), unreachable from a 1.x floor. Every 1.x range ends at `< 1.18.0`:

| Advisory | Sev | 1.x range | Issue |
|---|---|---|---|
| GHSA-gcfj-64vw-6mp9 | high | `>= 1.15.2, < 1.18.0` | Node adapter can use an inherited proxy |
| GHSA-xj6q-8x83-jv6g | mod | `>= 1.15.2, < 1.18.0` | prototype pollution via auth subfields |
| GHSA-hcpx-6fm6-wx23 | mod | `>= 1.15.1, < 1.18.0` | form serializer maxDepth bypass |
| GHSA-f4gw-2p7v-4548 | mod | `>= 1.15.0, < 1.18.0` | NO_PROXY bypass for 0.0.0.0 |
| GHSA-mwf2-3pr3-8698 | mod | `>= 1.13.0, < 1.18.0` | HTTP/2 uploads bypass maxBodyLength |
| GHSA-jqh4-m9w3-8hp9 | mod | `>= 1.7.0, < 1.18.0` | fetch ReadableStream upload bypass |
| GHSA-7q8q-rj6j-mhjq | mod | `>= 1.0.0, < 1.18.0` | nested option objects consume pollution |
| GHSA-mmx7-hfxf-jppx | mod | `>= 1.0.0, < 1.18.0` | prototype pollution gadgets |
| GHSA-42h9-826w-cgv3 | mod | `>= 1.0.0, < 1.18.0` | excessive recursion in formDataToJSON |
| GHSA-pmv8-rq9r-6j72 | mod | `>= 1.0.0, < 1.18.0` | deep formToJSON key recursion DoS |

Confirmed via the OSV API with the detector validated in **both** states: `axios@1.16.0` -> 10 vulns (IDs exactly matching the alerts), `axios@1.18.1` -> 0.

## Exact pins, deliberately

Every `dependencies` entry stays an exact pin, per `test_ui_package_versions_are_exact` — a self-tested repo invariant (its sibling `..._reports_offenders` proves the detector fires). An earlier revision of this PR used `^1.18.0` and correctly red-failed **two** checks, because the shared quality gate also runs the caller's pytest:

```
FAILED backend/tests/test_static_analysis_regressions.py::test_ui_package_versions_are_exact
  - AssertionError: ['dependencies:axios=^1.18.0']
```

The usual hazard of exact pins — Dependabot closing its own PRs as "up-to-date now" — is an **`overrides`** pathology, and does not apply: every `overrides` entry here already uses a bounded range, and the new `brace-expansion` entry follows that convention (`overrides` is not covered by the invariant).

## The two ignores, verified against this tree

Both were re-derived here rather than taken on trust.

**GHSA-mh99-v99m-4gvg** (`brace-expansion`, `<= 5.0.7`, first patched **5.0.8**) — genuinely unfixable. 5.0.8 is a major bump its consumers cannot take. **Measured here:** forcing `overrides.brace-expansion` to `^5.0.8` installs cleanly, then eslint dies:

```
TypeError: expand is not a function
    at Minimatch.braceExpand (node_modules/minimatch/minimatch.js:271:10)
```

Scope measured as **dev-only**: `npm ls brace-expansion --all --omit=dev` returns empty, both lockfile entries carry `dev=true`, and the only consumers are `eslint-plugin-import -> minimatch@3.1.5` and `typescript-eslint -> @typescript-eslint/typescript-estree -> minimatch@9.0.9`. Lint-time only; never in the shipped bundle. What *was* fixable is fixed: `^2.1.2` clears GHSA-3jxr on both lines.

**GHSA-qwww-vcr4-c8h2** (`react-router`, `>= 7.12.0, < 8.3.0`, first patched **8.3.0**) — no 7.x fix exists; 8.3.0 is a major framework migration that `dependabot.yml` also excludes via `version-update:semver-major`. The advisory affects React Router's **unstable RSC APIs**. Measured over `ui/src`: this is a plain Vite SPA on the **declarative router only** (`BrowserRouter`, `Routes`, `Route`, `Navigate`, `Link`, `Outlet`, `useNavigate`, `useLocation`, `useSearchParams`) with **zero** data-router/action surface (no `createBrowserRouter`, `RouterProvider`, `createRoutesFromElements`, `loader`, `action`, `useFetcher`, `useSubmit`, `useLoaderData`, `useActionData`, no `unstable_` API) and **zero** SSR/RSC surface (no `renderToString`, `renderToPipeableStream`, `hydrateRoot`, `react-server`, `entry.server`, `@react-router/node|serve|dev`). OSV controls: `react-router@7.15.1` -> 5 vulns, `@7.18.0` -> 1, `@8.3.0` -> 0.

Both carry `ignoreUntil = 2026-10-23` and a named re-check condition. **No other advisory is ignored.** The config was proven to parse *and* to be honoured: the scan prints `Filtered 2 vulnerabilities from output`, and a control run with a deliberately injected unknown key **loses** that line — so its presence is a real signal, not an assumption. Verified under both LF and CRLF, since `.toml` line endings normalize on checkout.

## Verification

Local, clean install from the regenerated lock:

| Step | Result |
|---|---|
| `npm ci --ignore-scripts` | rc=0 |
| `npm run lint` (eslint — also the brace-expansion consumer) | rc=0 |
| `vitest run --coverage` | rc=0 — 64 files, **100%** lines/branches/functions/statements |
| `tsc -b && vite build` | rc=0 |
| `pytest tests/test_static_analysis_regressions.py` | rc=0 — 4 passed |
| `osv-scanner 2.3.8` over `ui/package-lock.json` | **exit 0** — `Filtered 2 vulnerabilities from output`, `No issues found` |

CI: **`CI` success** and **`CodeQL` success** — `backend`, `backend-integration`, `frontend`, `e2e`, `docker-compose` all green. `e2e` passing is the meaningful signal for the react-router bump: Playwright drives the real stack through the router and the axios client.

## Remaining red is a third-party outage, not a vulnerability

`quality / quality` fails at `gate-deps`, and the log is explicit that this is **not** a security finding. All three scan attempts reported **zero** vulnerabilities:

```
Filtered 2 vulnerabilities from output
Total 0 packages affected by 0 known vulnerabilities (0 Critical, 0 High, 0 Medium, 0 Low, 0 Unknown) from 0 ecosystems.
RETRY gate-deps: osv-scanner exited 127 without completing the scan (attempt 1/3) - this is NOT a vulnerability finding; retrying in 20s.
...
ERROR gate-deps: osv-scanner could not complete the scan (exit 127) - this is NOT a vulnerability finding.
ERROR gate-deps: exit 127 means the scanner logged an error - commonly a deps.dev / registry resolver outage
  ("rpc error: code = Unavailable desc = service unavailable").
Process completed with exit code 75.
```

**Zero `osv.dev/GHSA` rows appear anywhere in the log** — there is no finding left to fix. `deps.dev` is currently unable to resolve the backend Python manifests (`failed resolution for backend/requirements.txt: rpc error: code = Unavailable desc = service unavailable`), so osv-scanner returns 127 (`HasErrored`). This was previously **masked**: while the npm tree still had vulnerabilities, `ErrVulnerabilitiesFound` (exit 1) preempted the `HasErrored` check. Fixing the vulnerabilities is what exposed the outage.

The gate blocks rather than passing an incomplete scan, which is correct fail-closed behaviour. Per its own instruction the remedy is to **re-run once upstream recovers** — no dependency change can or should affect it.

- No alert dismissed. No workflow pin, ruleset, or branch protection touched. No `--admin`. No break-glass label.
- Two `IgnoredVulns` entries only, both dated `2026-10-23`, both narrow, both with a re-check condition.
